### PR TITLE
feat: allow to catch url that does not end by /

### DIFF
--- a/express/index.ts
+++ b/express/index.ts
@@ -194,7 +194,7 @@ export function protectedResourceHandlerClerk(
 function getResourceUrl(req: express.Request) {
   const url = new URL(`${req.protocol}://${req.get("host")}${req.originalUrl}`);
   url.pathname = url.pathname.replace(
-    /\.well-known\/oauth-protected-resource\//,
+    /\.well-known\/oauth-protected-resource\/?/,
     ""
   );
   return url.toString();


### PR DESCRIPTION
I've recently tried to use Clerk Auth using MCP Servers, and when I was testing the authentication using MCP Inspector, when I took a look at the resource generated, the regex did not work - it was because it was trying to call the resource without the end backslash, causing the regex to fail. 

Just modifying the regex :) 