### PR TITLE
docs: fix bug in express readme

### DIFF
--- a/express/README.md
+++ b/express/README.md
@@ -70,7 +70,13 @@ server.tool(
   }
 );
 
-app.get("/.well-known/oauth-protected-resource", protectedResourceHandlerClerk);
+app.get("/.well-known/oauth-protected-resource", protectedResourceHandlerClerk());
+app.get(
+  "/.well-known/oauth-protected-resource/mcp",
+  protectedResourceHandlerClerk({
+    scopes_supported: ["profile", "email"],
+  })
+);
 app.get(
   "/.well-known/oauth-authorization-server",
   authServerMetadataHandlerClerk


### PR DESCRIPTION
need to call protectedResourceHandlerClerk so it returns its handler otherwise express hangs.

do we need the top level `oauth-protected-resource`? or just `.../mcp`?