### PR TITLE
Add Hono utilities and example

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ For detailed implementation guides and examples specific to your framework, see:
 
 - **[Express.js Integration](./express/README.md)** - Complete guide for building MCP servers with Express.js
 - **[Next.js Integration](./next/README.md)** - Complete guide for building both MCP servers and clients with Next.js
+- **[Hono Integration](./hono/README.md)** - Complete guide for building MCP servers with Hono
 
 ### Table of Contents
 

--- a/hono/README.md
+++ b/hono/README.md
@@ -53,9 +53,8 @@ server.tool(
   "get_clerk_user_data",
   {
     description: "Gets data about the Clerk user that authorized this request",
-    handler: async (_, { authInfo, ...mcpContext }) => {
-      // FIXME - This code won't work yet, still need to work out how to pass in the secret key to the MCP server
-      const clerk = createClerkClient({ secretKey: mcpContext.state.CLERK_SECRET_KEY! });
+    handler: async (_, { authInfo }) => {
+      const clerk = createClerkClient({ secretKey: process.env.CLERK_SECRET_KEY! });
 
       if (!authInfo?.extra?.userId) {
         return {

--- a/hono/README.md
+++ b/hono/README.md
@@ -30,6 +30,7 @@ import { McpServer } from "mcp-lite";
 import { createClerkClient } from "@clerk/backend";
 import {
   mcpAuthClerk,
+  oauthCorsMiddleware,
   protectedResourceHandlerClerk,
   authServerMetadataHandlerClerk,
 } from "@clerk/mcp-tools/hono";
@@ -55,6 +56,7 @@ server.tool(
     handler: async (_, { authInfo, ...mcpContext }) => {
       const clerkAuthInfo = authInfo;
 
+      // FIXME - This code won't work yet, still need to work out how to pass in the secret key to the MCP server
       const clerk = createClerkClient({ secretKey: mcpContext.state.CLERK_SECRET_KEY! });
 
       if (!clerkAuthInfo?.userId) {

--- a/hono/README.md
+++ b/hono/README.md
@@ -63,7 +63,7 @@ server.tool(
         };
       }
 
-      const user = await clerk.users.getUser(authInfo?.extra?.userId);
+      const user = await clerk.users.getUser(authInfo?.extra?.userId as string);
       return {
         content: [{ type: "text", text: JSON.stringify(user) }],
       };
@@ -104,8 +104,6 @@ app.post("/mcp", mcpAuthClerk, async (c) => {
 
 export default app;
 ```
-
-
 
 ## Authentication Middleware
 
@@ -165,6 +163,29 @@ app.get(
 
 **Note:** This handler requires the `CLERK_PUBLISHABLE_KEY` environment variable to be set, as it uses Clerk's public configuration to generate the metadata.
 
+## OAuth Metadata CORS Middleware
+
+### `oauthCorsMiddleware`
+
+Pre-configured CORS middleware specifically designed for OAuth protected resource metadata endpoints. This middleware is useful when testing authentication from browser-based MCP clients or the MCP inspector, for example with `npx @modelcontextprotocol/inspector`.
+
+**Example:**
+
+```ts
+import { oauthCorsMiddleware } from "@clerk/mcp-tools/hono";
+
+app.on(
+  ["GET", "OPTIONS"],
+  "/.well-known/oauth-protected-resource",
+  oauthCorsMiddleware, // <-- Apply CORS before your handler
+  protectedResourceHandlerClerk()
+);
+```
+
+This middleware uses `hono/cors` under the hood to automatically:
+
+- Handle preflight OPTIONS requests
+- Set appropriate CORS headers for OAuth metadata endpoints
 
 ## Accessing Authentication Data in Tools
 

--- a/hono/README.md
+++ b/hono/README.md
@@ -23,10 +23,10 @@ npm install @clerk/backend
 Here's a complete example using Clerk for authentication:
 
 ```ts
-import Hono from "hono";
+import { Hono } from "hono";
 import { logger } from "hono/logger";
 // Hono with auth does not play nicely with @modelcontextprotocol/sdk yet, so we use the mcp-lite package
-import { McpServer } from "mcp-lite";
+import { McpServer, StreamableHttpTransport } from "mcp-lite";
 import { createClerkClient } from "@clerk/backend";
 import {
   mcpAuthClerk,
@@ -52,20 +52,18 @@ const server = new McpServer({
 server.tool(
   "get_clerk_user_data",
   {
-    description: "Gets data about the Clerk user that authorized this request"
+    description: "Gets data about the Clerk user that authorized this request",
     handler: async (_, { authInfo, ...mcpContext }) => {
-      const clerkAuthInfo = authInfo;
-
       // FIXME - This code won't work yet, still need to work out how to pass in the secret key to the MCP server
       const clerk = createClerkClient({ secretKey: mcpContext.state.CLERK_SECRET_KEY! });
 
-      if (!clerkAuthInfo?.userId) {
+      if (!authInfo?.extra?.userId) {
         return {
           content: [{ type: "text", text: "Error: user not authenticated" }],
         };
       }
 
-      const user = await clerk.users.getUser(clerkAuthInfo.userId);
+      const user = await clerk.users.getUser(authInfo?.extra?.userId);
       return {
         content: [{ type: "text", text: JSON.stringify(user) }],
       };

--- a/hono/README.md
+++ b/hono/README.md
@@ -1,0 +1,251 @@
+# MCP Tools - Hono Integration
+
+Hono utilities for building MCP servers with authentication support. These tools make it easy to add MCP (Model Context Protocol) endpoints to your existing Hono applications.
+
+## Installation
+
+Make sure you have the required dependencies installed:
+
+```bash
+npm install @clerk/mcp-tools hono mcp-lite
+```
+
+If you're using Clerk for authentication, also install the Clerk backend SDK:
+
+```bash
+npm install @clerk/backend
+```
+
+## Quick Start
+
+### Example with Clerk Authentication
+
+Here's a complete example using Clerk for authentication:
+
+```ts
+import Hono from "hono";
+import { logger } from "hono/logger";
+// Hono with auth does not play nicely with @modelcontextprotocol/sdk yet, so we use the mcp-lite package
+import { McpServer } from "mcp-lite";
+import { createClerkClient } from "@clerk/backend";
+import {
+  mcpAuthClerk,
+  protectedResourceHandlerClerk,
+  authServerMetadataHandlerClerk,
+} from "@clerk/mcp-tools/hono";
+
+type AppType = {
+  Bindings: {
+    CLERK_SECRET_KEY: string;
+    CLERK_PUBLISHABLE_KEY: string;
+  }
+};
+
+const app = new Hono<AppType>();
+
+const server = new McpServer({
+  name: "clerk-mcp-server",
+  version: "1.0.0",
+});
+
+server.tool(
+  "get_clerk_user_data",
+  {
+    description: "Gets data about the Clerk user that authorized this request"
+    handler: async (_, { authInfo, ...mcpContext }) => {
+      const clerkAuthInfo = authInfo;
+
+      const clerk = createClerkClient({ secretKey: mcpContext.state.CLERK_SECRET_KEY! });
+
+      if (!clerkAuthInfo?.userId) {
+        return {
+          content: [{ type: "text", text: "Error: user not authenticated" }],
+        };
+      }
+
+      const user = await clerk.users.getUser(clerkAuthInfo.userId);
+      return {
+        content: [{ type: "text", text: JSON.stringify(user) }],
+      };
+    }
+  }
+);
+
+app.use(logger());
+
+app.on(
+  ["GET", "OPTIONS"],
+  "/.well-known/oauth-protected-resource",
+  oauthCorsMiddleware, // <-- cors middleware is helpful for testing in the inspector
+  protectedResourceHandlerClerk()
+);
+app.on(
+  ["GET", "OPTIONS"],
+  "/.well-known/oauth-protected-resource/mcp",
+  oauthCorsMiddleware,
+  protectedResourceHandlerClerk({
+    scopes_supported: ["profile", "email"],
+  })
+);
+app.on(
+  ["GET", "OPTIONS"],
+  "/.well-known/oauth-authorization-server",
+  oauthCorsMiddleware,
+  authServerMetadataHandlerClerk
+);
+
+app.post("/mcp", mcpAuthClerk, async (c) => {
+  const authInfo = c.get("auth");
+  const transport = new StreamableHttpTransport();
+  const mcpHttpHandler = transport.bind(server);
+  const response = await mcpHttpHandler(c.req.raw, { authInfo });
+  return response;
+});
+
+export default app;
+```
+
+
+
+## Authentication Middleware
+
+### `mcpAuthClerk`
+
+Pre-configured authentication middleware for Clerk that automatically handles OAuth token verification.
+
+**Example:**
+
+```ts
+import { mcpAuthClerk } from "@clerk/mcp-tools/hono";
+
+// No additional configuration needed - uses Clerk's built-in token verification
+app.post("/mcp", mcpAuthClerk, /** your mcp server handler */);
+```
+
+This middleware automatically:
+
+- Verifies OAuth access tokens using Clerk
+- Handles authentication state
+- Adds Clerk auth data to request context via `c.get("auth")`
+
+## Protected Resource Metadata
+
+### `protectedResourceHandlerClerk`
+
+Hono handler that returns OAuth protected resource metadata for Clerk integration, as required by [RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728).
+
+**Example:**
+
+```ts
+import { protectedResourceHandlerClerk } from "@clerk/mcp-tools/hono";
+
+app.get(
+  "/.well-known/oauth-protected-resource",
+  protectedResourceHandlerClerk({ scopes_supported: ["email"] })
+);
+```
+
+## Authorization Server Metadata
+
+### `authServerMetadataHandlerClerk`
+
+Hono handler that returns OAuth authorization server metadata for Clerk integration, as defined by [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414). This endpoint provides clients with information about Clerk's OAuth authorization server capabilities and endpoints.
+
+**Example:**
+
+```ts
+import { authServerMetadataHandlerClerk } from "@clerk/mcp-tools/hono";
+
+// Serve authorization server metadata at the standard well-known location
+app.get(
+  "/.well-known/oauth-authorization-server",
+  authServerMetadataHandlerClerk
+);
+```
+
+**Note:** This handler requires the `CLERK_PUBLISHABLE_KEY` environment variable to be set, as it uses Clerk's public configuration to generate the metadata.
+
+
+## Accessing Authentication Data in Tools
+
+Passing authentication data to your MCP tools is done via the `authInfo` parameter in the tool handler.
+
+The `@modelcontextprotocol/sdk` package requires that you do this by monkeypatching an `Express.Request` object, however, so it does not play nicely with Hono.
+
+The existing Hono MCP middleware does not yet support passing auth to MCP servers, but there is an open PR to add this support: https://github.com/honojs/middleware/pull/1318/files
+
+Alternative libraries like [`mcp-lite`](https://github.com/fiberplane/mcp) (used in the example above) do support the `authInfo` parameter, provided you pass it to the MCP server HTTP handler.
+
+```typescript
+import { McpServer } from "mcp-lite";
+
+const server = new McpServer({
+  name: "my-server",
+  version: "1.0.0",
+});
+
+server.tool(
+  "my-tool",
+  "My tool",
+  { type: "object", properties: {} },
+  async (args, { authInfo }) => {
+    return { content: [{ type: "text", text: `Hello, ${authInfo.extra.userId}!` }] };
+  }
+);
+
+app.post("/mcp", mcpAuthClerk, async (c) => {
+  const authInfo = c.get("auth");
+  const transport = new StreamableHttpTransport();
+  const mcpHttpHandler = transport.bind(server);
+  // pass the authInfo to the MCP server HTTP handler, making it available to the tool handlers
+  const response = await mcpHttpHandler(c.req.raw, { authInfo });
+  return response;
+});
+```
+
+## Environment Variables
+
+When using Clerk integration, make sure to set:
+
+```bash
+CLERK_PUBLISHABLE_KEY=pk_test_...
+CLERK_SECRET_KEY=sk_test_...
+```
+
+The publishable key is used for generating OAuth metadata, while the secret key is used for server-side API calls to fetch user data.
+
+## Error Handling
+
+The middleware automatically handles common authentication errors:
+
+- **Missing Authorization header**: Returns 401 with `WWW-Authenticate` header pointing to your protected resource metadata
+- **Invalid token format**: Throws an error with details about the expected format
+- **Token verification failure**: Returns 401 with error details
+
+## Integration with Existing Hono Apps
+
+These utilities are designed to integrate seamlessly with existing Hono applications. You can:
+
+- Add MCP endpoints to existing routes
+- Use your existing authentication middleware alongside MCP auth
+- Combine with other Hono middleware (CORS, rate limiting, etc.)
+
+```ts
+import cors from "cors";
+import { rateLimiter } from "hono-rate-limiter";
+
+// Apply middleware in the order you need
+app.use(cors());
+app.use(
+  rateLimiter({
+    windowMs: 15 * 60 * 1000,
+    limit: 100,
+  })
+);
+
+app.post(
+  "/mcp",
+  mcpAuthClerk, // MCP authentication
+  /** your mcp server handler */
+);
+```

--- a/hono/auth.ts
+++ b/hono/auth.ts
@@ -1,0 +1,68 @@
+import { createClerkClient } from "@clerk/backend";
+import { TokenType } from "@clerk/backend/internal";
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
+import { env } from "hono/adapter";
+import { createMiddleware } from "hono/factory";
+import { getPRMUrl } from "./utils.js";
+import { verifyClerkToken } from "../server";
+
+/**
+ * Hono middleware that enforces authentication for MCP requests using Clerk.
+ *
+ * Sets an "auth" variable on the request context, which matches the {@link AuthInfo} type from the MCP SDK.
+ */
+export const mcpAuthClerk = createMiddleware<
+  { Variables: { auth: AuthInfo } }
+>(async (c, next) => {
+  const authHeader = c.req.header("Authorization");
+  const [type, token] = authHeader?.split(" ") || [];
+  const bearerToken = type?.toLowerCase() === "bearer" ? token : undefined;
+
+  // Return 401 with proper www-authenticate header if no authorization is provided
+  if (!bearerToken) {
+    // Get the resource metadata url for the protected resource
+    // We return this in the `WWW-Authenticate` header so the MCP client knows where to find the protected resource metadata
+    const resourceMetadataUrl = getPRMUrl(c.req.raw);
+    c.header(
+      "WWW-Authenticate",
+      // NOTE - The mcp sdk also adds `error` and `error_description` to this header as well, depending on the error
+      //        see: https://github.com/modelcontextprotocol/typescript-sdk/blob/b28c297184cb0cb64611a3357d6438dd1b0824c6/src/server/auth/middleware/bearerAuth.ts#L76C1-L95C8
+      `Bearer resource_metadata="${resourceMetadataUrl}"`,
+    );
+    return c.json({ error: "Unauthorized" }, 401);
+  }
+
+  try {
+    const secretKey = (env(c)?.CLERK_SECRET_KEY || "") as string;
+    const publishableKey = (env(c)?.CLERK_PUBLISHABLE_KEY || "") as string;
+
+    const clerkClient = createClerkClient({
+      secretKey,
+      publishableKey,
+    });
+
+    const requestState = await clerkClient.authenticateRequest(c.req.raw, {
+      secretKey,
+      publishableKey,
+      acceptsToken: TokenType.OAuthToken,
+    });
+
+    // This is the result of the authenticateRequest call, with the `TokenType.OAuthToken` type
+    const auth = requestState.toAuth();
+
+    const authInfo = verifyClerkToken(auth, token);
+
+    // Require valid auth for this endpoint
+    if (!authInfo) {
+      return c.json({ error: "Unauthorized" }, 401);
+    }
+
+    // Attach auth to Request and Hono context for downstream handlers
+    c.set("auth", authInfo);
+
+    await next();
+  } catch (error) {
+    console.error("Unexpected mcp auth middleware error:", error);
+    return c.json({ error: "Internal Server Error" }, 500);
+  }
+});

--- a/hono/index.ts
+++ b/hono/index.ts
@@ -1,0 +1,6 @@
+export { mcpAuthClerk } from "./auth.js";
+export {
+  oauthCorsMiddleware,
+  protectedResourceHandlerClerk,
+  authServerMetadataHandlerClerk,
+} from "./oauth-server-routes.js";

--- a/hono/oauth-server-routes.ts
+++ b/hono/oauth-server-routes.ts
@@ -1,0 +1,94 @@
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { env } from "hono/adapter";
+import { createFactory } from "hono/factory";
+import {
+  corsHeaders,
+  fetchClerkAuthorizationServerMetadata,
+  generateClerkProtectedResourceMetadata,
+} from "../server";
+import { getResourceUrl } from "./utils.js";
+
+/**
+ * Create middleware to handle CORS for the OAuth endpoints,
+ * this is useful for testing auth from a browser-based MCP client,
+ * or the MCP inspector (`bunx @modelcontextprotocol/inspector`)
+ *
+ * @note We convert the CORS headers that we get from the @clerk/mcp-tools library
+ *       into a format that Hono middleware can understand
+ *
+ * @see https://github.com/clerk/mcp-tools/blob/main/server.ts
+ */
+export const oauthCorsMiddleware = cors({
+  origin: corsHeaders["Access-Control-Allow-Origin"],
+  // HACK - split the comma-separated list of methods into an array
+  allowMethods: corsHeaders["Access-Control-Allow-Methods"].split(","),
+  allowHeaders: [corsHeaders["Access-Control-Allow-Headers"]],
+  maxAge: parseInt(corsHeaders["Access-Control-Max-Age"], 10),
+});
+
+/**
+ * An Hono handler that will return OAuth protected resource metadata if you're using Clerk.
+ * @see https://datatracker.ietf.org/doc/html/rfc9728#section-4.1
+ * @example
+ * ```ts
+ * app.on(
+ *   ["GET", "OPTIONS"],
+ *   "/.well-known/oauth-protected-resource",
+ *   oauthCorsMiddleware,
+ *   protectedResourceHandlerClerk()
+ * );
+ * ```
+ */
+export const protectedResourceHandlerClerk = (
+  properties?: Record<string, unknown>
+) => {
+  const factory = createFactory();
+  const handlers = factory.createHandlers((c) => {
+    const publishableKey = env(c)?.CLERK_PUBLISHABLE_KEY;
+    if (!publishableKey) {
+      console.error(
+        "CLERK_PUBLISHABLE_KEY is not set for OAuth Authorization Server endpoint",
+      );
+      return c.json({ error: "Internal Server Error" }, 500);
+    }
+
+    const resourceUrl = getResourceUrl(c.req.raw);
+
+    const result = generateClerkProtectedResourceMetadata({
+      publishableKey: publishableKey as string,
+      resourceUrl,
+      properties,
+    });
+
+    return c.json(result);
+  })
+  return handlers[0];
+}
+
+const authServerFactory = createFactory();
+const authServerHandlers = authServerFactory.createHandlers(async (c) => {
+  const publishableKey = env(c)?.CLERK_PUBLISHABLE_KEY;
+  if (!publishableKey) {
+    console.error(
+      "CLERK_PUBLISHABLE_KEY is not set for OAuth Authorization Server endpoint",
+    );
+    return c.json({ error: "Internal Server Error" }, 500);
+  }
+
+  // If CLERK_PUBLISHABLE_KEY is misconfigured, this will result in a 500
+  const result = await fetchClerkAuthorizationServerMetadata({
+    publishableKey: publishableKey as string,
+  });
+
+  return c.json(result);
+});
+
+/**
+ * Implement the OAuth Authorization Server endpoint
+ *
+ * @note - In this case, Clerk is the authorization server, so we shouldn't *need* to implement this;
+ *         however, in earlier versions of the MCP spec (prior to 2025-06-18), this route was expected/required,
+ *         so we implement it for backwards compatibility with clients.
+ */
+export const authServerMetadataHandlerClerk = authServerHandlers[0];

--- a/hono/oauth-server-routes.ts
+++ b/hono/oauth-server-routes.ts
@@ -12,10 +12,10 @@ import { getResourceUrl } from "./utils.js";
 /**
  * Create middleware to handle CORS for the OAuth endpoints,
  * this is useful for testing auth from a browser-based MCP client,
- * or the MCP inspector (`bunx @modelcontextprotocol/inspector`)
+ * or the MCP inspector (`npx @modelcontextprotocol/inspector`)
  *
- * @note We convert the CORS headers that we get from the @clerk/mcp-tools library
- *       into a format that Hono middleware can understand
+ * @note Converts the CORS headers object from the @clerk/mcp-tools library
+ *       into a format that Hono's CORS middleware can understand
  *
  * @see https://github.com/clerk/mcp-tools/blob/main/server.ts
  */
@@ -28,7 +28,12 @@ export const oauthCorsMiddleware = cors({
 });
 
 /**
- * An Hono handler that will return OAuth protected resource metadata if you're using Clerk.
+ * A Hono handler that will return OAuth protected resource metadata if you're using Clerk.
+ *
+ * Typically mounted at the routes:
+ * - `/.well-known/oauth-protected-resource`
+ * - `/.well-known/oauth-protected-resource/mcp`
+ *
  * @see https://datatracker.ietf.org/doc/html/rfc9728#section-4.1
  * @example
  * ```ts
@@ -37,6 +42,13 @@ export const oauthCorsMiddleware = cors({
  *   "/.well-known/oauth-protected-resource",
  *   oauthCorsMiddleware,
  *   protectedResourceHandlerClerk()
+ * );
+ *
+ * app.on(
+ *   ["GET", "OPTIONS"],
+ *   "/.well-known/oauth-protected-resource/mcp",
+ *   oauthCorsMiddleware,
+ *   protectedResourceHandlerClerk({  scopes_supported: ["profile", "email"] })
  * );
  * ```
  */
@@ -87,8 +99,10 @@ const authServerHandlers = authServerFactory.createHandlers(async (c) => {
 /**
  * Implement the OAuth Authorization Server endpoint
  *
- * @note - In this case, Clerk is the authorization server, so we shouldn't *need* to implement this;
+ * Typically mounted at the route `/.well-known/oauth-authorization-server`
+ *
+ * @note - In this case, Clerk is the authorization server, so you shouldn't *need* to implement this;
  *         however, in earlier versions of the MCP spec (prior to 2025-06-18), this route was expected/required,
- *         so we implement it for backwards compatibility with clients.
+ *         so you can implement it for backwards compatibility with clients.
  */
 export const authServerMetadataHandlerClerk = authServerHandlers[0];

--- a/hono/utils.ts
+++ b/hono/utils.ts
@@ -1,0 +1,19 @@
+/**
+ * Given a protected resource metadata url generate the url of the original resource
+ */
+export function getResourceUrl(req: Request) {
+  const url = new URL(req.url);
+  url.pathname = url.pathname.replace(
+    /\.well-known\/oauth-protected-resource\/?/,
+    "",
+  );
+  return url.toString();
+}
+
+/**
+ * Get given a request, generate a protected resource metadata url for the given resource url
+ */
+export function getPRMUrl(req: Request) {
+  const url = new URL(req.url);
+  return `${url.origin}/.well-known/oauth-protected-resource${url.pathname}`;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,19 @@
 {
   "name": "@clerk/mcp-tools",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clerk/mcp-tools",
-      "version": "0.2.1",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.0"
+        "@modelcontextprotocol/sdk": "^1.17.0",
+        "mcp-lite": "^0.2.1"
       },
       "devDependencies": {
+        "@clerk/backend": "^2.14.0",
         "@clerk/express": "^1.7.12",
         "@clerk/nextjs": "^6.26.0",
         "@types/better-sqlite3": "^7.6.13",
@@ -19,6 +21,7 @@
         "@types/node": "^24.1.0",
         "@types/pg": "^8.15.4",
         "better-sqlite3": "^11.10.0",
+        "hono": "^4.9.7",
         "next": "^15.4.4",
         "pg": "^8.16.3",
         "redis": "^5.5.6",
@@ -43,16 +46,15 @@
       }
     },
     "node_modules/@clerk/backend": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.5.2.tgz",
-      "integrity": "sha512-m3AsF3lOGUmzZOmMg7ovL5l8lzNHExM3mgRGguaOz9vAenRLPT9U+h+GVGP7URv6IPWVI5jhywlU8+MOK5tUIg==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-2.14.0.tgz",
+      "integrity": "sha512-EaPXIaOb3IVyn+3NRX9GVZeKk1eL1ugWOiyPzy7hfJvxRYhTBatZrwd32+nCkQ6igvRpRG4O+o5vWS1tSErbrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@clerk/shared": "^3.15.0",
-        "@clerk/types": "^4.70.0",
+        "@clerk/shared": "^3.25.0",
+        "@clerk/types": "^4.86.0",
         "cookie": "1.0.2",
-        "snakecase-keys": "9.0.2",
         "standardwebhooks": "^1.0.0",
         "tslib": "2.8.1"
       },
@@ -132,14 +134,14 @@
       }
     },
     "node_modules/@clerk/shared": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.15.0.tgz",
-      "integrity": "sha512-yPsRYAJYSyniJItmXjz6eHOHcR75+SZV9K/UPp1djz/vyu4CCyndz83kc9xTa7MG/1Sfz2yKIIhyyB/21bjDoQ==",
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-3.25.0.tgz",
+      "integrity": "sha512-2Vb6NQqBA+1g7kfGct/OlSFmzU54/s4BQp3qeHwDqW1FgaU4MuXbqfBClI6AatxOC8Ux8W16Rvf705ViwFSxlw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@clerk/types": "^4.70.0",
+        "@clerk/types": "^4.86.0",
         "dequal": "2.0.3",
         "glob-to-regexp": "0.4.1",
         "js-cookie": "3.0.5",
@@ -163,9 +165,9 @@
       }
     },
     "node_modules/@clerk/types": {
-      "version": "4.70.0",
-      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.70.0.tgz",
-      "integrity": "sha512-WYqxeNVqeshuHRj0t+nIS5be0WlIqjudLamhqCNkstpkxSiVDHF1lyGEjPVYmbXwOzdnZoPtFqWEaiBEGaboJA==",
+      "version": "4.86.0",
+      "resolved": "https://registry.npmjs.org/@clerk/types/-/types-4.86.0.tgz",
+      "integrity": "sha512-YFaOYIAZWbpXehAmtgUB0YNf1v5b/hlwePvdqxlD5vdwrNsap28RpupWZat0hp1+PTtb9uAwSa5AFCOxkYLUJQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1651,6 +1653,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -2073,13 +2081,6 @@
         }
       ],
       "license": "CC-BY-4.0"
-    },
-    "node_modules/change-case": {
-      "version": "5.4.4",
-      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
-      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/chokidar": {
       "version": "4.0.3",
@@ -2811,6 +2812,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hono": {
+      "version": "4.9.7",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.7.tgz",
+      "integrity": "sha512-t4Te6ERzIaC48W3x4hJmBwgNlLhmiEdEE5ViYb02ffw4ignHNHa5IBtPjmbKstmtKa8X6C35iWwK4HaqvrzG9w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -3008,19 +3019,6 @@
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
-    "node_modules/map-obj": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-5.0.2.tgz",
-      "integrity": "sha512-K6K2NgKnTXimT3779/4KxSvobxOtMmx1LBZ3NwRxT/MDIR3Br/fQ4Q+WCX5QxjyUR8zg5+RV9Tbf2c5pAWTD2A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3028,6 +3026,14 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mcp-lite": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/mcp-lite/-/mcp-lite-0.2.1.tgz",
+      "integrity": "sha512-E/Y301Gu7a8O0IPzGAgL6HaXG4yfu+SZusWZz9C6v27OMvwRtnNanZqKCnox9r27zryY3rlWmA2DuHctqWMzqA==",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0"
       }
     },
     "node_modules/media-typer": {
@@ -4180,21 +4186,6 @@
         "is-arrayish": "^0.3.1"
       }
     },
-    "node_modules/snakecase-keys": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/snakecase-keys/-/snakecase-keys-9.0.2.tgz",
-      "integrity": "sha512-Tr4gONsDj1Pa6HJH9D3b411r6tuRyCGgb1l7YpzDFp/thjVSWs7rcbNjyTyRqJi5SUV23sFpzf9epIJRbLR6Yw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "change-case": "^5.4.4",
-        "map-obj": "^5.0.2",
-        "type-fest": "^4.15.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.8.0-beta.0",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz",
@@ -4624,19 +4615,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "dev": true,
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.17.0",
-        "mcp-lite": "^0.2.1"
+        "@modelcontextprotocol/sdk": "^1.17.0"
       },
       "devDependencies": {
         "@clerk/backend": "^2.14.0",
@@ -30,11 +29,15 @@
       },
       "peerDependencies": {
         "better-sqlite3": "^8.7.0",
+        "hono": "^4.0",
         "pg": "^8.11.0",
         "redis": "^4.0.0"
       },
       "peerDependenciesMeta": {
         "better-sqlite3": {
+          "optional": true
+        },
+        "hono": {
           "optional": true
         },
         "pg": {
@@ -1653,12 +1656,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
-      "license": "MIT"
-    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -3026,14 +3023,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/mcp-lite": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/mcp-lite/-/mcp-lite-0.2.1.tgz",
-      "integrity": "sha512-E/Y301Gu7a8O0IPzGAgL6HaXG4yfu+SZusWZz9C6v27OMvwRtnNanZqKCnox9r27zryY3rlWmA2DuHctqWMzqA==",
-      "dependencies": {
-        "@standard-schema/spec": "^1.0.0"
       }
     },
     "node_modules/media-typer": {

--- a/package.json
+++ b/package.json
@@ -87,7 +87,6 @@
     "@types/pg": "^8.15.4",
     "better-sqlite3": "^11.10.0",
     "hono": "^4.9.7",
-    "mcp-lite": "^0.2.1",
     "next": "^15.4.4",
     "pg": "^8.16.3",
     "redis": "^5.5.6",
@@ -97,15 +96,11 @@
   "peerDependencies": {
     "better-sqlite3": "^8.7.0",
     "hono": "^4.0",
-    "mcp-lite": "^0.2.1",
     "pg": "^8.11.0",
     "redis": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "hono": {
-      "optional": true
-    },
-    "mcp-lite": {
       "optional": true
     },
     "redis": {
@@ -137,7 +132,6 @@
     "clean": true,
     "external": [
       "hono",
-      "mcp-lite",
       "redis",
       "pg",
       "better-sqlite3"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
       "import": "./dist/express/index.js",
       "types": "./dist/express/index.d.ts"
     },
+    "./hono": {
+      "import": "./dist/hono/index.js",
+      "types": "./dist/hono/index.d.ts"
+    },
     "./stores": "./dist/stores",
     "./stores/fs": {
       "import": "./dist/stores/fs.js",
@@ -71,9 +75,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.0"
+    "@modelcontextprotocol/sdk": "^1.17.0",
+    "mcp-lite": "^0.2.1"
   },
   "devDependencies": {
+    "@clerk/backend": "^2.14.0",
     "@clerk/express": "^1.7.12",
     "@clerk/nextjs": "^6.26.0",
     "@types/better-sqlite3": "^7.6.13",
@@ -81,6 +87,7 @@
     "@types/node": "^24.1.0",
     "@types/pg": "^8.15.4",
     "better-sqlite3": "^11.10.0",
+    "hono": "^4.9.7",
     "next": "^15.4.4",
     "pg": "^8.16.3",
     "redis": "^5.5.6",
@@ -109,6 +116,7 @@
       "server.ts",
       "next/index.ts",
       "express/index.ts",
+      "hono/index.ts",
       "stores/fs.ts",
       "stores/redis.ts",
       "stores/postgres.ts",

--- a/package.json
+++ b/package.json
@@ -75,8 +75,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.0",
-    "mcp-lite": "^0.2.1"
+    "@modelcontextprotocol/sdk": "^1.17.0"
   },
   "devDependencies": {
     "@clerk/backend": "^2.14.0",
@@ -88,6 +87,7 @@
     "@types/pg": "^8.15.4",
     "better-sqlite3": "^11.10.0",
     "hono": "^4.9.7",
+    "mcp-lite": "^0.2.1",
     "next": "^15.4.4",
     "pg": "^8.16.3",
     "redis": "^5.5.6",
@@ -96,10 +96,18 @@
   },
   "peerDependencies": {
     "better-sqlite3": "^8.7.0",
+    "hono": "^4.0",
+    "mcp-lite": "^0.2.1",
     "pg": "^8.11.0",
     "redis": "^4.0.0"
   },
   "peerDependenciesMeta": {
+    "hono": {
+      "optional": true
+    },
+    "mcp-lite": {
+      "optional": true
+    },
     "redis": {
       "optional": true
     },
@@ -128,6 +136,8 @@
     "dts": true,
     "clean": true,
     "external": [
+      "hono",
+      "mcp-lite",
       "redis",
       "pg",
       "better-sqlite3"


### PR DESCRIPTION
## Overview

Adds a new folder `hono/` with utilities and examples for building an authenticated (Hono-based) MCP server with Clerk.

At the moment, this PR focuses on Clerk utilities only, and does not export general-purpose helpers like the `express/` module does.

### Worth Noting

Web Standard api frameworks like Hono do not play nicely with the `@modelcontextprotocol/sdk` typescript package, since that package is rather Express-and-Node.js specific.

(This is why Hono has its own package for building MCP servers, which re-implements the StreamableHTTPTransport under the hood.)

Currently, the Hono mcp middleware does not have a way to pass auth down to tools (it's [WIP](https://github.com/honojs/middleware/pull/1318/files)), but this is something that the `mcp-lite` SDK does (disclosure: I am a maintainer), which is why I included it in an example.

### Exports of `@clerk/mcp-tools/hono`

- `mcpAuthClerk` - Hono authentication middleware
- `oauthCorsMiddleware` - cors middleware for the oauth metadata handlers
- `protectedResourceHandlerClerk` - handler that returns metadata for the resource server (Hono app)
- `authServerMetadataHandlerClerk` - handler that returns Clerk auth server metadata

## How I tested

I published this package under a different scope (`@bretterplane/mcp-tools`) and made sure the example from the Hono README worked in the repo [here](https://github.com/brettimus/clerk-mcp-tools-hono-test) without import or type errors.

To configure Clerk, I created an application, then enabled OAuth + DCR.

To test the auth flow, I ran the `@modelcontextprotocol/inspector` and used the guided OAuth flow to check each step. (Discovery, client registration, etc.)

Finally, I used the inspector to execute the authenticated tool, and it worked (fetching auth'd user info from Clerk).

## TODOs

- [ ] Add general purpose mcp auth utils? (Utilities that do not assume usage of Clerk)
- [x] Update `hono/README.md` to fix `get_clerk_user_data` tool
- [x] Update `hono/README.md` to document `oauthCorsMiddleware`
- [x] Test the Hono utilities in the wild with a published package (I will do this)
