### PR TITLE
Add explicit addition of `scopes_supported`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@clerk/mcp-tools",
-  "version": "0.2.1",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@clerk/mcp-tools",
-      "version": "0.2.1",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.17.0"

--- a/server.ts
+++ b/server.ts
@@ -55,10 +55,14 @@ export function generateProtectedResourceMetadata({
 export function generateClerkProtectedResourceMetadata({
   publishableKey,
   resourceUrl,
+  scopesSupported,
   properties,
 }: {
   publishableKey: string;
   resourceUrl: string;
+  scopesSupported?: Array<
+    "profile" | "email" | "public_metadata" | "private_metadata" | "openid"
+  >;
   properties?: Record<string, unknown>;
 }) {
   const fapiUrl = deriveFapiUrl(publishableKey);
@@ -68,6 +72,7 @@ export function generateClerkProtectedResourceMetadata({
     resourceUrl,
     properties: {
       service_documentation: "https://clerk.com/docs",
+      scopes_supported: scopesSupported,
       ...properties,
     },
   });


### PR DESCRIPTION
## Changes
As defined by [RFC9728](https://datatracker.ietf.org/doc/html/rfc9728#name-scopes), the resource metadata supports optionally `scopes_supported`

We add support for this explicitly with the Clerk protected resource handler to be provided

## Why?
Even though it is optional, I've noticed from testing that currently, `mcp-tools` does not work for dynamic client registration + oauth flow for VS Code since internally it dynamically registers the client with the scopes of the resource only. Because nothing is returned for scopes, Clerk setups up the default of `email` and `profile` for the client. However, when VS code submits an auth request, it uses the scopes from the auth server ie. `openid`, and fails since the client does not support this scope.

I think VS Code needs fix this logic internally, but for now, by providing the `scopes_supported`, this will make VS Code work properly and registers the client with the correct scopes and uses the client scopes for auth
