### PR TITLE
feat: add CommonJS exports, @clerk/backend as peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,35 +30,43 @@
   "exports": {
     "./client": {
       "import": "./dist/client.js",
+      "require": "./dist/client.cjs",
       "types": "./dist/client.d.ts"
     },
     "./server": {
       "import": "./dist/server.js",
+      "require": "./dist/server.cjs",
       "types": "./dist/server.d.ts"
     },
     "./next": {
       "import": "./dist/next/index.js",
+      "require": "./dist/next/index.cjs",
       "types": "./dist/next/index.d.ts"
     },
     "./express": {
       "import": "./dist/express/index.js",
+      "require": "./dist/express/index.cjs",
       "types": "./dist/express/index.d.ts"
     },
     "./stores": "./dist/stores",
     "./stores/fs": {
       "import": "./dist/stores/fs.js",
+      "require": "./dist/stores/fs.cjs",
       "types": "./dist/stores/fs.d.ts"
     },
     "./stores/redis": {
       "import": "./dist/stores/redis.js",
+      "require": "./dist/stores/redis.cjs",
       "types": "./dist/stores/redis.d.ts"
     },
     "./stores/postgres": {
       "import": "./dist/stores/postgres.js",
+      "require": "./dist/stores/postgres.cjs",
       "types": "./dist/stores/postgres.d.ts"
     },
     "./stores/sqlite": {
       "import": "./dist/stores/sqlite.js",
+      "require": "./dist/stores/sqlite.cjs",
       "types": "./dist/stores/sqlite.d.ts"
     }
   },
@@ -76,6 +84,7 @@
   "devDependencies": {
     "@clerk/express": "^1.7.12",
     "@clerk/nextjs": "^6.26.0",
+    "@clerk/backend": "^2.25.1",
     "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.3",
     "@types/node": "^24.1.0",
@@ -88,6 +97,7 @@
     "typescript": "^5.8.3"
   },
   "peerDependencies": {
+    "@clerk/backend": "^2.25.1",
     "better-sqlite3": "^8.7.0",
     "pg": "^8.11.0",
     "redis": "^4.0.0"
@@ -115,7 +125,8 @@
       "stores/sqlite.ts"
     ],
     "format": [
-      "esm"
+      "esm",
+      "cjs"
     ],
     "dts": true,
     "clean": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,9 @@ importers:
         specifier: ^1.17.0
         version: 1.17.0
     devDependencies:
+      '@clerk/backend':
+        specifier: ^2.25.1
+        version: 2.25.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@clerk/express':
         specifier: ^1.7.12
         version: 1.7.12(express@5.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -51,8 +54,8 @@ importers:
 
 packages:
 
-  '@clerk/backend@2.5.2':
-    resolution: {integrity: sha512-m3AsF3lOGUmzZOmMg7ovL5l8lzNHExM3mgRGguaOz9vAenRLPT9U+h+GVGP7URv6IPWVI5jhywlU8+MOK5tUIg==}
+  '@clerk/backend@2.25.1':
+    resolution: {integrity: sha512-L5JeWWuMAxBfxip6RKglBhKVywykJwMaSo2NkW8pfjM9INQ/JtpXTlVl5SKSv5v43vSkKxYeqKXkXyNgtxRPaQ==}
     engines: {node: '>=18.17.0'}
 
   '@clerk/clerk-react@5.36.0':
@@ -87,6 +90,22 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  '@clerk/shared@3.38.0':
+    resolution: {integrity: sha512-9R63kyHXq4DntdQXWxwpFZSq04AR8rby0cqAnUfTsAddyxQOmyjgHZADKkrMYUbhGiJnLBysUmZBPyVizjaopg==}
+    engines: {node: '>=18.17.0'}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  '@clerk/types@4.101.5':
+    resolution: {integrity: sha512-LEfEizGRM0hN/8GHaia8EIf7kcTHKh2R/Ebj7n1zETB88HrCrM6mvTVv/fqpf5203F1GsCR/UU2l18EOClfWGA==}
+    engines: {node: '>=18.17.0'}
 
   '@clerk/types@4.70.0':
     resolution: {integrity: sha512-WYqxeNVqeshuHRj0t+nIS5be0WlIqjudLamhqCNkstpkxSiVDHF1lyGEjPVYmbXwOzdnZoPtFqWEaiBEGaboJA==}
@@ -734,9 +753,6 @@ packages:
   caniuse-lite@1.0.30001718:
     resolution: {integrity: sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==}
 
-  change-case@5.4.4:
-    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
-
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -1052,10 +1068,6 @@ packages:
 
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
-
-  map-obj@5.0.2:
-    resolution: {integrity: sha512-K6K2NgKnTXimT3779/4KxSvobxOtMmx1LBZ3NwRxT/MDIR3Br/fQ4Q+WCX5QxjyUR8zg5+RV9Tbf2c5pAWTD2A==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1403,10 +1415,6 @@ packages:
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
 
-  snakecase-keys@9.0.2:
-    resolution: {integrity: sha512-Tr4gONsDj1Pa6HJH9D3b411r6tuRyCGgb1l7YpzDFp/thjVSWs7rcbNjyTyRqJi5SUV23sFpzf9epIJRbLR6Yw==}
-    engines: {node: '>=22'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1536,10 +1544,6 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
-
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -1610,12 +1614,11 @@ packages:
 
 snapshots:
 
-  '@clerk/backend@2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@clerk/backend@2.25.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@clerk/shared': 3.15.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@clerk/types': 4.70.0
+      '@clerk/shared': 3.38.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@clerk/types': 4.101.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       cookie: 1.0.2
-      snakecase-keys: 9.0.2
       standardwebhooks: 1.0.0
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -1632,7 +1635,7 @@ snapshots:
 
   '@clerk/express@1.7.12(express@5.1.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@clerk/backend': 2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@clerk/backend': 2.25.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@clerk/shared': 3.15.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@clerk/types': 4.70.0
       express: 5.1.0
@@ -1643,7 +1646,7 @@ snapshots:
 
   '@clerk/nextjs@6.26.0(next@15.4.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
-      '@clerk/backend': 2.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@clerk/backend': 2.25.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@clerk/clerk-react': 5.36.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@clerk/shared': 3.15.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@clerk/types': 4.70.0
@@ -1664,6 +1667,25 @@ snapshots:
     optionalDependencies:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+
+  '@clerk/shared@3.38.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      csstype: 3.1.3
+      dequal: 2.0.3
+      glob-to-regexp: 0.4.1
+      js-cookie: 3.0.5
+      std-env: 3.9.0
+      swr: 2.3.4(react@19.1.0)
+    optionalDependencies:
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@clerk/types@4.101.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@clerk/shared': 3.38.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+    transitivePeerDependencies:
+      - react
+      - react-dom
 
   '@clerk/types@4.70.0':
     dependencies:
@@ -2139,8 +2161,6 @@ snapshots:
 
   caniuse-lite@1.0.30001718: {}
 
-  change-case@5.4.4: {}
-
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -2458,8 +2478,6 @@ snapshots:
   magic-string@0.30.17:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.0
-
-  map-obj@5.0.2: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -2855,12 +2873,6 @@ snapshots:
       is-arrayish: 0.3.2
     optional: true
 
-  snakecase-keys@9.0.2:
-    dependencies:
-      change-case: 5.4.4
-      map-obj: 5.0.2
-      type-fest: 4.41.0
-
   source-map-js@1.2.1: {}
 
   source-map@0.8.0-beta.0:
@@ -2998,8 +3010,6 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
-
-  type-fest@4.41.0: {}
 
   type-is@2.0.1:
     dependencies:


### PR DESCRIPTION
This PR adds CommonJS (CJS) build output to the package. While ESM is the standard, many backend frameworks—most notably NestJS—still default to or rely heavily on CommonJS/require for module loading.

### Problem
Currently, attempting to import this package in a CJS environment (like a standard NestJS application or a TypeScript project compiling to CJS) results in the following runtime error:

`Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './express' is not defined by "exports" in ...`

This happens because node is looking for a require entry in the exports map but only finds import.