### PR TITLE
chore(repo): Change the publish workflow user

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,13 +23,13 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.CLERK_COOKIE_PAT }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -46,8 +46,8 @@ jobs:
 
       - name: Configure git
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "clerk-cookie"
+          git config user.email "cookie@clerk.dev"
 
       - name: Bump version
         if: ${{ inputs.version != 'none' }}


### PR DESCRIPTION
We disallow pushes to main for all users except Clerk Cookie.

This addresses https://clerkinc.slack.com/archives/C08LBCCKKRU/p1776808124597079?thread_ts=1770659374.915759&cid=C08LBCCKKRU