### PR TITLE
feat: Introduce Hono adapter

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,7 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm dedupe --check
+      - run: pnpm lint
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Lint
+name: CI
 permissions:
   contents: read
 
@@ -18,3 +18,14 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm dedupe --check
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
+          node-version: '24'
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm dedupe --check
@@ -27,6 +28,7 @@ jobs:
       - uses: pnpm/action-setup@v4
       - uses: actions/setup-node@v4
         with:
+          node-version: '24'
           cache: 'pnpm'
       - run: pnpm install
       - run: pnpm test

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This library has tools for both of these parties, so step one is to be clear on 
 For detailed implementation guides and examples specific to your framework, see:
 
 - **[Express.js Integration](./express/README.md)** - Complete guide for building MCP servers with Express.js
+- **[Hono Integration](./hono/README.md)** - Complete guide for building MCP servers with Hono and edge runtimes
 - **[Next.js Integration](./next/README.md)** - Complete guide for building both MCP servers and clients with Next.js
 
 ### Table of Contents
@@ -72,6 +73,7 @@ const result = generateClerkProtectedResourceMetadata({
 For framework-specific implementations of protected resource metadata handlers, see:
 
 - [Express.js implementation](./express/README.md#protected-resource-metadata)
+- [Hono implementation](./hono/README.md)
 - [Next.js implementation](./next/README.md#protectedresourcehandler)
 
 #### Authorization server metadata
@@ -124,6 +126,7 @@ const result = generateClerkAuthorizationServerMetadata();
 For framework-specific implementations, see:
 
 - [Express.js implementation](./express/README.md)
+- [Hono implementation](./hono/README.md)
 - [Next.js implementation](./next/README.md#authservermetadatahandlerclerk)
 
 #### Creating an MCP endpoint
@@ -131,6 +134,7 @@ For framework-specific implementations, see:
 To create an MCP endpoint that handles the actual MCP protocol communication, you'll need to use framework-specific adapters, since each framework has its own way of handling request and response objects, which are critical parts of implementing the MCP protocol:
 
 - **Express.js**: Use the `streamableHttpHandler` from `@clerk/mcp-tools/express` - see [Express.js guide](./express/README.md#mcp-request-handler)
+- **Hono**: Use the `streamableHttpHandler` from `@clerk/mcp-tools/hono` - see [Hono guide](./hono/README.md)
 - **Next.js**: Use Vercel's MCP adapter with Next.js route handlers - see [Next.js guide](./next/README.md#building-an-mcp-server)
 
 These adapters handle the MCP protocol details and integrate with your authentication system.
@@ -670,6 +674,7 @@ The above examples are more of a _guide_ for how to implement the tools, but for
 For detailed documentation on server utilities and framework-specific implementations, see:
 
 - [Express.js server guide](./express/README.md)
+- [Hono server guide](./hono/README.md)
 - [Next.js server guide](./next/README.md#building-an-mcp-server)
 
 #### Framework-Specific Utilities
@@ -677,4 +682,5 @@ For detailed documentation on server utilities and framework-specific implementa
 For framework-specific utilities and handlers, see:
 
 - **Express.js**: See [Express.js reference documentation](./express/README.md)
+- **Hono**: See [Hono reference documentation](./hono/README.md)
 - **Next.js**: See [Next.js reference documentation](./next/README.md)

--- a/hono/README.md
+++ b/hono/README.md
@@ -1,0 +1,112 @@
+# MCP Tools - Hono Integration
+
+Hono utilities for building MCP servers with authentication support.
+
+## Installation
+
+```bash
+npm install @clerk/mcp-tools hono @modelcontextprotocol/sdk
+```
+
+If you're using Clerk for authentication, also install:
+
+```bash
+npm install @clerk/hono
+```
+
+## Quick Start
+
+### With Clerk Authentication
+
+```ts
+import { Hono } from 'hono';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { clerkMiddleware } from '@clerk/hono';
+import {
+  mcpAuthClerk,
+  protectedResourceHandlerClerk,
+  authServerMetadataHandlerClerk,
+  streamableHttpHandler,
+} from '@clerk/mcp-tools/hono';
+
+const app = new Hono();
+app.use(clerkMiddleware());
+
+const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+
+server.tool('get_user', 'Gets the current user', {}, async (_, { authInfo }) => ({
+  content: [{ type: 'text', text: JSON.stringify(authInfo) }],
+}));
+
+app.get('/.well-known/oauth-protected-resource', protectedResourceHandlerClerk());
+app.get('/.well-known/oauth-authorization-server', authServerMetadataHandlerClerk);
+app.post('/mcp', mcpAuthClerk, streamableHttpHandler(server));
+
+export default app;
+```
+
+### With Custom Authentication
+
+```ts
+import { Hono } from 'hono';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  mcpAuth,
+  protectedResourceHandler,
+  streamableHttpHandler,
+} from '@clerk/mcp-tools/hono';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+
+const app = new Hono();
+
+const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+
+app.get(
+  '/.well-known/oauth-protected-resource',
+  protectedResourceHandler({ authServerUrl: 'https://auth.example.com' }),
+);
+
+app.post(
+  '/mcp',
+  mcpAuth(async (token, c): Promise<AuthInfo | undefined> => {
+    // verify token with your auth provider
+    const user = await verifyMyToken(token);
+    if (!user) return undefined;
+    return {
+      token,
+      scopes: user.scopes,
+      clientId: user.clientId,
+      extra: { userId: user.id },
+    };
+  }),
+  streamableHttpHandler(server),
+);
+
+export default app;
+```
+
+## Reference
+
+### `mcpAuth(verifyToken)`
+
+Middleware that enforces authentication for MCP requests. Extracts the bearer token from the `Authorization` header, calls `verifyToken`, and stores the result in Hono context for downstream handlers (`c.get('mcpAuth')`). Returns `401` with a `WWW-Authenticate` header if auth fails.
+
+### `mcpAuthClerk`
+
+Pre-configured middleware that verifies tokens using Clerk. Requires `clerkMiddleware()` to be mounted and `CLERK_PUBLISHABLE_KEY` to be set.
+
+### `protectedResourceHandler({ authServerUrl, properties? })`
+
+Handler that returns OAuth 2.0 Protected Resource Metadata (RFC 9728). Derives the resource URL from the current request path.
+
+### `protectedResourceHandlerClerk(properties?)`
+
+Same as `protectedResourceHandler`, but derives `authServerUrl` automatically from `CLERK_PUBLISHABLE_KEY`.
+
+### `authServerMetadataHandlerClerk`
+
+Handler that fetches and returns Clerk's OAuth Authorization Server Metadata. Requires `CLERK_PUBLISHABLE_KEY`.
+
+### `streamableHttpHandler(server)`
+
+Handler that connects an `McpServer` instance to a `WebStandardStreamableHTTPServerTransport` and processes the request. Passes any auth info set by `mcpAuth`/`mcpAuthClerk` through to the MCP server.

--- a/hono/README.md
+++ b/hono/README.md
@@ -32,15 +32,17 @@ import {
 const app = new Hono();
 app.use('*', clerkMiddleware());
 
-const server = new McpServer({ name: 'my-server', version: '1.0.0' });
-
-server.tool('get_user', 'Gets the current user', {}, async (_, { authInfo }) => ({
-  content: [{ type: 'text', text: JSON.stringify(authInfo) }],
-}));
+function createServer() {
+  const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+  server.tool('get_user', 'Gets the current user', {}, async (_, { authInfo }) => ({
+    content: [{ type: 'text', text: JSON.stringify(authInfo) }],
+  }));
+  return server;
+}
 
 app.get('/.well-known/oauth-protected-resource', protectedResourceHandlerClerk());
 app.get('/.well-known/oauth-authorization-server', authServerMetadataHandlerClerk);
-app.post('/mcp', mcpAuthClerk, streamableHttpHandler(server));
+app.post('/mcp', mcpAuthClerk, streamableHttpHandler(createServer));
 
 export default app;
 ```
@@ -55,7 +57,9 @@ import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 
 const app = new Hono();
 
-const server = new McpServer({ name: 'my-server', version: '1.0.0' });
+function createServer() {
+  return new McpServer({ name: 'my-server', version: '1.0.0' });
+}
 
 app.get(
   '/.well-known/oauth-protected-resource',
@@ -74,7 +78,7 @@ app.post(
       extra: { userId: user.id },
     };
   }),
-  streamableHttpHandler(server),
+  streamableHttpHandler(createServer),
 );
 
 export default app;
@@ -102,6 +106,6 @@ Same as `protectedResourceHandler`, but derives `authServerUrl` automatically fr
 
 Handler that fetches and returns Clerk's OAuth Authorization Server Metadata. Requires `CLERK_PUBLISHABLE_KEY`.
 
-### `streamableHttpHandler(server)`
+### `streamableHttpHandler(createServer)`
 
-Handler that connects an `McpServer` instance to a `WebStandardStreamableHTTPServerTransport` and processes the request. Passes any auth info set by `mcpAuth`/`mcpAuthClerk` through to the MCP server.
+Handler that creates an `McpServer` and `WebStandardStreamableHTTPServerTransport` for each request. Passes any auth info set by `mcpAuth`/`mcpAuthClerk` through to the MCP server. The factory must return a new server instance on every call so concurrent and abandoned requests remain isolated.

--- a/hono/README.md
+++ b/hono/README.md
@@ -30,7 +30,7 @@ import {
 } from '@clerk/mcp-tools/hono';
 
 const app = new Hono();
-app.use(clerkMiddleware());
+app.use('*', clerkMiddleware());
 
 const server = new McpServer({ name: 'my-server', version: '1.0.0' });
 
@@ -50,11 +50,7 @@ export default app;
 ```ts
 import { Hono } from 'hono';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import {
-  mcpAuth,
-  protectedResourceHandler,
-  streamableHttpHandler,
-} from '@clerk/mcp-tools/hono';
+import { mcpAuth, protectedResourceHandler, streamableHttpHandler } from '@clerk/mcp-tools/hono';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 
 const app = new Hono();
@@ -69,7 +65,6 @@ app.get(
 app.post(
   '/mcp',
   mcpAuth(async (token, c): Promise<AuthInfo | undefined> => {
-    // verify token with your auth provider
     const user = await verifyMyToken(token);
     if (!user) return undefined;
     return {

--- a/hono/index.test.ts
+++ b/hono/index.test.ts
@@ -1,0 +1,311 @@
+import { Hono } from 'hono';
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('../server', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../server')>();
+  return {
+    ...actual,
+    fetchClerkAuthorizationServerMetadata: vi.fn().mockResolvedValue({
+      issuer: 'https://clerk.example.com',
+      authorization_endpoint: 'https://clerk.example.com/authorize',
+    }),
+  };
+});
+
+vi.mock('@clerk/hono', () => ({
+  getAuth: vi.fn(),
+}));
+
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import { getAuth } from '@clerk/hono';
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
+import {
+  protectedResourceHandler,
+  protectedResourceHandlerClerk,
+  authServerMetadataHandlerClerk,
+  mcpAuth,
+  mcpAuthClerk,
+  streamableHttpHandler,
+} from './index';
+
+// A fake publishable key that decodes to "https://clerk.example.com"
+// Buffer.from('clerk.example.com$').toString('base64') === 'Y2xlcmsuZXhhbXBsZS5jb20k'
+const FAKE_PK = 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k';
+
+describe('protectedResourceHandler', () => {
+  test('returns metadata with auth server URL and derived resource URL', async () => {
+    const app = new Hono();
+    app.get(
+      '/.well-known/oauth-protected-resource',
+      protectedResourceHandler({ authServerUrl: 'https://auth.example.com' }),
+    );
+
+    const res = await app.request(
+      'http://myapp.com/.well-known/oauth-protected-resource',
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.resource).toBe('http://myapp.com/');
+    expect(json.authorization_servers).toEqual(['https://auth.example.com']);
+  });
+
+  test('strips sub-path from resource URL', async () => {
+    const app = new Hono();
+    app.get(
+      '/.well-known/oauth-protected-resource/mcp',
+      protectedResourceHandler({ authServerUrl: 'https://auth.example.com' }),
+    );
+
+    const res = await app.request(
+      'http://myapp.com/.well-known/oauth-protected-resource/mcp',
+    );
+    const json = await res.json();
+    expect(json.resource).toBe('http://myapp.com/mcp');
+  });
+
+  test('merges additional properties', async () => {
+    const app = new Hono();
+    app.get(
+      '/.well-known/oauth-protected-resource',
+      protectedResourceHandler({
+        authServerUrl: 'https://auth.example.com',
+        properties: { scopes_supported: ['read', 'write'] },
+      }),
+    );
+
+    const res = await app.request(
+      'http://myapp.com/.well-known/oauth-protected-resource',
+    );
+    const json = await res.json();
+    expect(json.scopes_supported).toEqual(['read', 'write']);
+  });
+});
+
+describe('protectedResourceHandlerClerk', () => {
+  beforeEach(() => {
+    process.env.CLERK_PUBLISHABLE_KEY = FAKE_PK;
+  });
+
+  afterEach(() => {
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+  });
+
+  test('derives auth server URL from CLERK_PUBLISHABLE_KEY', async () => {
+    const app = new Hono();
+    app.get(
+      '/.well-known/oauth-protected-resource',
+      protectedResourceHandlerClerk(),
+    );
+
+    const res = await app.request(
+      'http://myapp.com/.well-known/oauth-protected-resource',
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.authorization_servers).toEqual(['https://clerk.example.com']);
+    expect(json.resource).toBe('http://myapp.com/');
+  });
+
+  test('returns 500 when CLERK_PUBLISHABLE_KEY is missing', async () => {
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+    const app = new Hono();
+    app.get(
+      '/.well-known/oauth-protected-resource',
+      protectedResourceHandlerClerk(),
+    );
+
+    const res = await app.request(
+      'http://myapp.com/.well-known/oauth-protected-resource',
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('authServerMetadataHandlerClerk', () => {
+  beforeEach(() => {
+    process.env.CLERK_PUBLISHABLE_KEY = FAKE_PK;
+  });
+
+  afterEach(() => {
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+  });
+
+  test('returns fetched Clerk metadata', async () => {
+    const app = new Hono();
+    app.get('/.well-known/oauth-authorization-server', authServerMetadataHandlerClerk);
+
+    const res = await app.request(
+      'http://myapp.com/.well-known/oauth-authorization-server',
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.issuer).toBe('https://clerk.example.com');
+  });
+
+  test('returns 500 when CLERK_PUBLISHABLE_KEY is missing', async () => {
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+    const app = new Hono();
+    app.get('/.well-known/oauth-authorization-server', authServerMetadataHandlerClerk);
+
+    const res = await app.request(
+      'http://myapp.com/.well-known/oauth-authorization-server',
+    );
+    expect(res.status).toBe(500);
+  });
+});
+
+describe('mcpAuth', () => {
+  test('returns 401 with WWW-Authenticate when Authorization header is missing', async () => {
+    const app = new Hono();
+    app.get('/mcp', mcpAuth(async () => undefined), (c) => c.json({ ok: true }));
+
+    const res = await app.request('http://localhost/mcp');
+    expect(res.status).toBe(401);
+    const wwwAuth = res.headers.get('WWW-Authenticate');
+    expect(wwwAuth).toMatch(/^Bearer resource_metadata=/);
+  });
+
+  test('returns 401 when verifyToken returns undefined', async () => {
+    const app = new Hono();
+    app.get('/mcp', mcpAuth(async () => undefined), (c) => c.json({ ok: true }));
+
+    const res = await app.request('http://localhost/mcp', {
+      headers: { Authorization: 'Bearer bad-token' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('calls next and stores authInfo in context when token is valid', async () => {
+    const authInfo: AuthInfo = {
+      token: 'valid',
+      scopes: ['read'],
+      clientId: 'client-1',
+      extra: { userId: 'user-1' },
+    };
+    const app = new Hono();
+    app.get(
+      '/mcp',
+      mcpAuth(async () => authInfo),
+      (c) => c.json(c.get('mcpAuth')),
+    );
+
+    const res = await app.request('http://localhost/mcp', {
+      headers: { Authorization: 'Bearer valid' },
+    });
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual(authInfo);
+  });
+
+  test('passes token and context to verifyToken', async () => {
+    const verifyToken = vi.fn().mockResolvedValue(undefined);
+    const app = new Hono();
+    app.get('/mcp', mcpAuth(verifyToken), (c) => c.json({ ok: true }));
+
+    await app.request('http://localhost/mcp', {
+      headers: { Authorization: 'Bearer my-token' },
+    });
+
+    expect(verifyToken).toHaveBeenCalledWith('my-token', expect.any(Object));
+  });
+});
+
+describe('mcpAuthClerk', () => {
+  test('returns 401 when Clerk auth is not authenticated', async () => {
+    vi.mocked(getAuth).mockReturnValue({ isAuthenticated: false } as any);
+
+    const app = new Hono();
+    app.post('/mcp', mcpAuthClerk, (c) => c.json({ ok: true }));
+
+    const res = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token' },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test('sets authInfo in context when Clerk auth succeeds', async () => {
+    vi.mocked(getAuth).mockReturnValue({
+      isAuthenticated: true,
+      tokenType: 'oauth_token',
+      clientId: 'client-1',
+      scopes: ['read', 'email'],
+      userId: 'user-1',
+    } as any);
+
+    const app = new Hono();
+    app.post('/mcp', mcpAuthClerk, (c) => c.json(c.get('mcpAuth')));
+
+    const res = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer valid-token' },
+    });
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({
+      token: 'valid-token',
+      scopes: ['read', 'email'],
+      clientId: 'client-1',
+      extra: { userId: 'user-1' },
+    });
+  });
+});
+
+describe('streamableHttpHandler', () => {
+  test('handles an MCP initialize request and returns 200', async () => {
+    const server = new McpServer({ name: 'test-server', version: '1.0.0' });
+    const app = new Hono();
+    app.post('/mcp', streamableHttpHandler(server));
+
+    const res = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+
+  test('forwards authInfo from context to the transport', async () => {
+    const authInfo: AuthInfo = {
+      token: 'tok',
+      scopes: ['read'],
+      clientId: 'c1',
+      extra: { userId: 'u1' },
+    };
+    const server = new McpServer({ name: 'test-server', version: '1.0.0' });
+    const app = new Hono();
+    app.post(
+      '/mcp',
+      (c, next) => { c.set('mcpAuth', authInfo); return next(); },
+      streamableHttpHandler(server),
+    );
+
+    const res = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(200);
+  });
+});

--- a/hono/index.test.ts
+++ b/hono/index.test.ts
@@ -306,6 +306,7 @@ describe('streamableHttpHandler', () => {
     const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body };
 
     const res1 = await app.request('http://localhost/mcp', opts);
+    await res1.text(); // consume body so transport is released for next request
     const res2 = await app.request('http://localhost/mcp', opts);
 
     expect(res1.status).toBe(200);

--- a/hono/index.test.ts
+++ b/hono/index.test.ts
@@ -25,6 +25,7 @@ import { getAuth } from '@clerk/hono';
 import { env } from 'hono/adapter';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { generateClerkProtectedResourceMetadata } from '../server';
 
 import {
   protectedResourceHandler,
@@ -113,6 +114,22 @@ describe('protectedResourceHandlerClerk', () => {
     const json = await res.json();
     expect(json.authorization_servers).toEqual(['https://clerk.example.com']);
     expect(json.resource).toBe('http://myapp.com/');
+  });
+
+  test('works in edge runtimes without Node.js Buffer', () => {
+    const metadata = (() => {
+      vi.stubGlobal('Buffer', undefined);
+      try {
+        return generateClerkProtectedResourceMetadata({
+          publishableKey: FAKE_PK,
+          resourceUrl: 'https://mcp.example.com',
+        });
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    })();
+
+    expect(metadata.authorization_servers).toEqual(['https://clerk.example.com']);
   });
 
   test('reads CLERK_PUBLISHABLE_KEY through Hono adapter env', async () => {
@@ -350,6 +367,7 @@ describe('streamableHttpHandler', () => {
     });
 
     expect(res.status).toBe(200);
+    await res.text();
   });
 
   test('handles sequential requests against the same server instance', async () => {
@@ -369,6 +387,28 @@ describe('streamableHttpHandler', () => {
 
     expect(res1.status).toBe(200);
     expect(res2.status).toBe(200);
+    await res2.text();
+  });
+
+  test('queues a new request until the previous response releases the server', async () => {
+    const server = new McpServer({ name: 'test-server', version: '1.0.0' });
+    const app = new Hono();
+    app.post('/mcp', streamableHttpHandler(server));
+
+    const opts = {
+      method: 'POST',
+      headers: mcpHeaders,
+      body: initializeBody,
+    };
+
+    const res1 = await app.request('http://localhost/mcp', opts);
+    const res2Promise = app.request('http://localhost/mcp', opts);
+    await res1.text();
+    const res2 = await res2Promise;
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    await res2.text();
   });
 
   test('forwards authInfo from context to the transport', async () => {
@@ -396,6 +436,7 @@ describe('streamableHttpHandler', () => {
     });
 
     expect(res.status).toBe(200);
+    await res.text();
   });
 
   test('returns SDK 406 response when POST Accept header is missing', async () => {

--- a/hono/index.test.ts
+++ b/hono/index.test.ts
@@ -209,6 +209,18 @@ describe('mcpAuth', () => {
 
     expect(verifyToken).toHaveBeenCalledWith('my-token', expect.any(Object));
   });
+
+  test('returns 401 when Authorization header has no token value', async () => {
+    const app = new Hono();
+    app.get('/mcp', mcpAuth(async () => undefined), (c) => c.json({ ok: true }));
+
+    const res = await app.request('http://localhost/mcp', {
+      headers: { Authorization: 'Bearer' },
+    });
+    expect(res.status).toBe(401);
+    const wwwAuth = res.headers.get('WWW-Authenticate');
+    expect(wwwAuth).toMatch(/^Bearer resource_metadata=/);
+  });
 });
 
 describe('mcpAuthClerk', () => {
@@ -274,6 +286,30 @@ describe('streamableHttpHandler', () => {
     });
 
     expect(res.status).toBe(200);
+  });
+
+  test('handles sequential requests against the same server instance', async () => {
+    const server = new McpServer({ name: 'test-server', version: '1.0.0' });
+    const app = new Hono();
+    app.post('/mcp', streamableHttpHandler(server));
+
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'test-client', version: '1.0.0' },
+      },
+    });
+    const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body };
+
+    const res1 = await app.request('http://localhost/mcp', opts);
+    const res2 = await app.request('http://localhost/mcp', opts);
+
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
   });
 
   test('forwards authInfo from context to the transport', async () => {

--- a/hono/index.test.ts
+++ b/hono/index.test.ts
@@ -16,8 +16,13 @@ vi.mock('@clerk/hono', () => ({
   getAuth: vi.fn(),
 }));
 
+vi.mock('hono/adapter', () => ({
+  env: vi.fn(() => process.env),
+}));
+
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { getAuth } from '@clerk/hono';
+import { env } from 'hono/adapter';
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 
@@ -30,9 +35,21 @@ import {
   streamableHttpHandler,
 } from './index';
 
-// A fake publishable key that decodes to "https://clerk.example.com"
-// Buffer.from('clerk.example.com$').toString('base64') === 'Y2xlcmsuZXhhbXBsZS5jb20k'
 const FAKE_PK = 'pk_test_Y2xlcmsuZXhhbXBsZS5jb20k';
+const mcpHeaders = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json, text/event-stream',
+};
+const initializeBody = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'initialize',
+  params: {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'test-client', version: '1.0.0' },
+  },
+});
 
 describe('protectedResourceHandler', () => {
   test('returns metadata with auth server URL and derived resource URL', async () => {
@@ -42,9 +59,7 @@ describe('protectedResourceHandler', () => {
       protectedResourceHandler({ authServerUrl: 'https://auth.example.com' }),
     );
 
-    const res = await app.request(
-      'http://myapp.com/.well-known/oauth-protected-resource',
-    );
+    const res = await app.request('http://myapp.com/.well-known/oauth-protected-resource');
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.resource).toBe('http://myapp.com/');
@@ -58,9 +73,7 @@ describe('protectedResourceHandler', () => {
       protectedResourceHandler({ authServerUrl: 'https://auth.example.com' }),
     );
 
-    const res = await app.request(
-      'http://myapp.com/.well-known/oauth-protected-resource/mcp',
-    );
+    const res = await app.request('http://myapp.com/.well-known/oauth-protected-resource/mcp');
     const json = await res.json();
     expect(json.resource).toBe('http://myapp.com/mcp');
   });
@@ -75,9 +88,7 @@ describe('protectedResourceHandler', () => {
       }),
     );
 
-    const res = await app.request(
-      'http://myapp.com/.well-known/oauth-protected-resource',
-    );
+    const res = await app.request('http://myapp.com/.well-known/oauth-protected-resource');
     const json = await res.json();
     expect(json.scopes_supported).toEqual(['read', 'write']);
   });
@@ -85,6 +96,7 @@ describe('protectedResourceHandler', () => {
 
 describe('protectedResourceHandlerClerk', () => {
   beforeEach(() => {
+    vi.mocked(env).mockImplementation(() => process.env);
     process.env.CLERK_PUBLISHABLE_KEY = FAKE_PK;
   });
 
@@ -94,37 +106,41 @@ describe('protectedResourceHandlerClerk', () => {
 
   test('derives auth server URL from CLERK_PUBLISHABLE_KEY', async () => {
     const app = new Hono();
-    app.get(
-      '/.well-known/oauth-protected-resource',
-      protectedResourceHandlerClerk(),
-    );
+    app.get('/.well-known/oauth-protected-resource', protectedResourceHandlerClerk());
 
-    const res = await app.request(
-      'http://myapp.com/.well-known/oauth-protected-resource',
-    );
+    const res = await app.request('http://myapp.com/.well-known/oauth-protected-resource');
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.authorization_servers).toEqual(['https://clerk.example.com']);
     expect(json.resource).toBe('http://myapp.com/');
   });
 
+  test('reads CLERK_PUBLISHABLE_KEY through Hono adapter env', async () => {
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+    vi.mocked(env).mockReturnValue({ CLERK_PUBLISHABLE_KEY: FAKE_PK });
+
+    const app = new Hono();
+    app.get('/.well-known/oauth-protected-resource', protectedResourceHandlerClerk());
+
+    const res = await app.request('http://myapp.com/.well-known/oauth-protected-resource');
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.authorization_servers).toEqual(['https://clerk.example.com']);
+  });
+
   test('returns 500 when CLERK_PUBLISHABLE_KEY is missing', async () => {
     delete process.env.CLERK_PUBLISHABLE_KEY;
     const app = new Hono();
-    app.get(
-      '/.well-known/oauth-protected-resource',
-      protectedResourceHandlerClerk(),
-    );
+    app.get('/.well-known/oauth-protected-resource', protectedResourceHandlerClerk());
 
-    const res = await app.request(
-      'http://myapp.com/.well-known/oauth-protected-resource',
-    );
+    const res = await app.request('http://myapp.com/.well-known/oauth-protected-resource');
     expect(res.status).toBe(500);
   });
 });
 
 describe('authServerMetadataHandlerClerk', () => {
   beforeEach(() => {
+    vi.mocked(env).mockImplementation(() => process.env);
     process.env.CLERK_PUBLISHABLE_KEY = FAKE_PK;
   });
 
@@ -136,9 +152,20 @@ describe('authServerMetadataHandlerClerk', () => {
     const app = new Hono();
     app.get('/.well-known/oauth-authorization-server', authServerMetadataHandlerClerk);
 
-    const res = await app.request(
-      'http://myapp.com/.well-known/oauth-authorization-server',
-    );
+    const res = await app.request('http://myapp.com/.well-known/oauth-authorization-server');
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.issuer).toBe('https://clerk.example.com');
+  });
+
+  test('reads CLERK_PUBLISHABLE_KEY through Hono adapter env', async () => {
+    delete process.env.CLERK_PUBLISHABLE_KEY;
+    vi.mocked(env).mockReturnValue({ CLERK_PUBLISHABLE_KEY: FAKE_PK });
+
+    const app = new Hono();
+    app.get('/.well-known/oauth-authorization-server', authServerMetadataHandlerClerk);
+
+    const res = await app.request('http://myapp.com/.well-known/oauth-authorization-server');
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json.issuer).toBe('https://clerk.example.com');
@@ -149,9 +176,7 @@ describe('authServerMetadataHandlerClerk', () => {
     const app = new Hono();
     app.get('/.well-known/oauth-authorization-server', authServerMetadataHandlerClerk);
 
-    const res = await app.request(
-      'http://myapp.com/.well-known/oauth-authorization-server',
-    );
+    const res = await app.request('http://myapp.com/.well-known/oauth-authorization-server');
     expect(res.status).toBe(500);
   });
 });
@@ -159,7 +184,11 @@ describe('authServerMetadataHandlerClerk', () => {
 describe('mcpAuth', () => {
   test('returns 401 with WWW-Authenticate when Authorization header is missing', async () => {
     const app = new Hono();
-    app.get('/mcp', mcpAuth(async () => undefined), (c) => c.json({ ok: true }));
+    app.get(
+      '/mcp',
+      mcpAuth(async () => undefined),
+      (c) => c.json({ ok: true }),
+    );
 
     const res = await app.request('http://localhost/mcp');
     expect(res.status).toBe(401);
@@ -169,7 +198,11 @@ describe('mcpAuth', () => {
 
   test('returns 401 when verifyToken returns undefined', async () => {
     const app = new Hono();
-    app.get('/mcp', mcpAuth(async () => undefined), (c) => c.json({ ok: true }));
+    app.get(
+      '/mcp',
+      mcpAuth(async () => undefined),
+      (c) => c.json({ ok: true }),
+    );
 
     const res = await app.request('http://localhost/mcp', {
       headers: { Authorization: 'Bearer bad-token' },
@@ -212,7 +245,11 @@ describe('mcpAuth', () => {
 
   test('returns 401 when Authorization header has no token value', async () => {
     const app = new Hono();
-    app.get('/mcp', mcpAuth(async () => undefined), (c) => c.json({ ok: true }));
+    app.get(
+      '/mcp',
+      mcpAuth(async () => undefined),
+      (c) => c.json({ ok: true }),
+    );
 
     const res = await app.request('http://localhost/mcp', {
       headers: { Authorization: 'Bearer' },
@@ -221,11 +258,47 @@ describe('mcpAuth', () => {
     const wwwAuth = res.headers.get('WWW-Authenticate');
     expect(wwwAuth).toMatch(/^Bearer resource_metadata=/);
   });
+
+  test('returns 401 and does not verify when Authorization scheme is not Bearer', async () => {
+    const verifyToken = vi.fn().mockResolvedValue({
+      token: 'valid',
+      scopes: ['read'],
+      clientId: 'client-1',
+    });
+    const app = new Hono();
+    app.get('/mcp', mcpAuth(verifyToken), (c) => c.json({ ok: true }));
+
+    const res = await app.request('http://localhost/mcp', {
+      headers: { Authorization: 'Basic valid' },
+    });
+
+    expect(res.status).toBe(401);
+    expect(verifyToken).not.toHaveBeenCalled();
+    expect(res.headers.get('WWW-Authenticate')).toMatch(/^Bearer resource_metadata=/);
+  });
+
+  test('returns 401 and does not verify when Bearer header has extra parts', async () => {
+    const verifyToken = vi.fn().mockResolvedValue({
+      token: 'valid',
+      scopes: ['read'],
+      clientId: 'client-1',
+    });
+    const app = new Hono();
+    app.get('/mcp', mcpAuth(verifyToken), (c) => c.json({ ok: true }));
+
+    const res = await app.request('http://localhost/mcp', {
+      headers: { Authorization: 'Bearer valid extra' },
+    });
+
+    expect(res.status).toBe(401);
+    expect(verifyToken).not.toHaveBeenCalled();
+    expect(res.headers.get('WWW-Authenticate')).toMatch(/^Bearer resource_metadata=/);
+  });
 });
 
 describe('mcpAuthClerk', () => {
   test('returns 401 when Clerk auth is not authenticated', async () => {
-    vi.mocked(getAuth).mockReturnValue({ isAuthenticated: false } as any);
+    vi.mocked(getAuth).mockReturnValue({ isAuthenticated: false } as ReturnType<typeof getAuth>);
 
     const app = new Hono();
     app.post('/mcp', mcpAuthClerk, (c) => c.json({ ok: true }));
@@ -244,7 +317,7 @@ describe('mcpAuthClerk', () => {
       clientId: 'client-1',
       scopes: ['read', 'email'],
       userId: 'user-1',
-    } as any);
+    } as ReturnType<typeof getAuth>);
 
     const app = new Hono();
     app.post('/mcp', mcpAuthClerk, (c) => c.json(c.get('mcpAuth')));
@@ -272,17 +345,8 @@ describe('streamableHttpHandler', () => {
 
     const res = await app.request('http://localhost/mcp', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'initialize',
-        params: {
-          protocolVersion: '2024-11-05',
-          capabilities: {},
-          clientInfo: { name: 'test-client', version: '1.0.0' },
-        },
-      }),
+      headers: mcpHeaders,
+      body: initializeBody,
     });
 
     expect(res.status).toBe(200);
@@ -293,17 +357,11 @@ describe('streamableHttpHandler', () => {
     const app = new Hono();
     app.post('/mcp', streamableHttpHandler(server));
 
-    const body = JSON.stringify({
-      jsonrpc: '2.0',
-      id: 1,
-      method: 'initialize',
-      params: {
-        protocolVersion: '2024-11-05',
-        capabilities: {},
-        clientInfo: { name: 'test-client', version: '1.0.0' },
-      },
-    });
-    const opts = { method: 'POST', headers: { 'Content-Type': 'application/json' }, body };
+    const opts = {
+      method: 'POST',
+      headers: mcpHeaders,
+      body: initializeBody,
+    };
 
     const res1 = await app.request('http://localhost/mcp', opts);
     await res1.text(); // consume body so transport is released for next request
@@ -324,25 +382,37 @@ describe('streamableHttpHandler', () => {
     const app = new Hono();
     app.post(
       '/mcp',
-      (c, next) => { c.set('mcpAuth', authInfo); return next(); },
+      (c, next) => {
+        c.set('mcpAuth', authInfo);
+        return next();
+      },
       streamableHttpHandler(server),
     );
 
     const res = await app.request('http://localhost/mcp', {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'initialize',
-        params: {
-          protocolVersion: '2024-11-05',
-          capabilities: {},
-          clientInfo: { name: 'test-client', version: '1.0.0' },
-        },
-      }),
+      headers: mcpHeaders,
+      body: initializeBody,
     });
 
     expect(res.status).toBe(200);
+  });
+
+  test('returns SDK 406 response when POST Accept header is missing', async () => {
+    const server = new McpServer({ name: 'test-server', version: '1.0.0' });
+    const app = new Hono();
+    app.post('/mcp', streamableHttpHandler(server));
+
+    const res = await app.request('http://localhost/mcp', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: initializeBody,
+    });
+
+    expect(res.status).toBe(406);
+    const json = await res.json();
+    expect(json.error.message).toContain(
+      'Client must accept both application/json and text/event-stream',
+    );
   });
 });

--- a/hono/index.test.ts
+++ b/hono/index.test.ts
@@ -52,6 +52,10 @@ const initializeBody = JSON.stringify({
   },
 });
 
+function createMcpServer() {
+  return new McpServer({ name: 'test-server', version: '1.0.0' });
+}
+
 describe('protectedResourceHandler', () => {
   test('returns metadata with auth server URL and derived resource URL', async () => {
     const app = new Hono();
@@ -356,9 +360,8 @@ describe('mcpAuthClerk', () => {
 
 describe('streamableHttpHandler', () => {
   test('handles an MCP initialize request and returns 200', async () => {
-    const server = new McpServer({ name: 'test-server', version: '1.0.0' });
     const app = new Hono();
-    app.post('/mcp', streamableHttpHandler(server));
+    app.post('/mcp', streamableHttpHandler(createMcpServer));
 
     const res = await app.request('http://localhost/mcp', {
       method: 'POST',
@@ -370,10 +373,9 @@ describe('streamableHttpHandler', () => {
     await res.text();
   });
 
-  test('handles sequential requests against the same server instance', async () => {
-    const server = new McpServer({ name: 'test-server', version: '1.0.0' });
+  test('handles sequential requests', async () => {
     const app = new Hono();
-    app.post('/mcp', streamableHttpHandler(server));
+    app.post('/mcp', streamableHttpHandler(createMcpServer));
 
     const opts = {
       method: 'POST',
@@ -382,7 +384,7 @@ describe('streamableHttpHandler', () => {
     };
 
     const res1 = await app.request('http://localhost/mcp', opts);
-    await res1.text(); // consume body so transport is released for next request
+    await res1.text();
     const res2 = await app.request('http://localhost/mcp', opts);
 
     expect(res1.status).toBe(200);
@@ -390,10 +392,10 @@ describe('streamableHttpHandler', () => {
     await res2.text();
   });
 
-  test('queues a new request until the previous response releases the server', async () => {
-    const server = new McpServer({ name: 'test-server', version: '1.0.0' });
+  test('does not block a new request on an unconsumed response', async () => {
+    const createServer = vi.fn(createMcpServer);
     const app = new Hono();
-    app.post('/mcp', streamableHttpHandler(server));
+    app.post('/mcp', streamableHttpHandler(createServer));
 
     const opts = {
       method: 'POST',
@@ -402,12 +404,12 @@ describe('streamableHttpHandler', () => {
     };
 
     const res1 = await app.request('http://localhost/mcp', opts);
-    const res2Promise = app.request('http://localhost/mcp', opts);
-    await res1.text();
-    const res2 = await res2Promise;
+    const res2 = await app.request('http://localhost/mcp', opts);
 
     expect(res1.status).toBe(200);
     expect(res2.status).toBe(200);
+    expect(createServer).toHaveBeenCalledTimes(2);
+    await res1.text();
     await res2.text();
   });
 
@@ -418,7 +420,6 @@ describe('streamableHttpHandler', () => {
       clientId: 'c1',
       extra: { userId: 'u1' },
     };
-    const server = new McpServer({ name: 'test-server', version: '1.0.0' });
     const app = new Hono();
     app.post(
       '/mcp',
@@ -426,7 +427,7 @@ describe('streamableHttpHandler', () => {
         c.set('mcpAuth', authInfo);
         return next();
       },
-      streamableHttpHandler(server),
+      streamableHttpHandler(createMcpServer),
     );
 
     const res = await app.request('http://localhost/mcp', {
@@ -440,9 +441,8 @@ describe('streamableHttpHandler', () => {
   });
 
   test('returns SDK 406 response when POST Accept header is missing', async () => {
-    const server = new McpServer({ name: 'test-server', version: '1.0.0' });
     const app = new Hono();
-    app.post('/mcp', streamableHttpHandler(server));
+    app.post('/mcp', streamableHttpHandler(createMcpServer));
 
     const res = await app.request('http://localhost/mcp', {
       method: 'POST',

--- a/hono/index.ts
+++ b/hono/index.ts
@@ -1,0 +1,135 @@
+import { getAuth } from '@clerk/hono';
+import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
+import type { Context, MiddlewareHandler, Next } from 'hono';
+import {
+  fetchClerkAuthorizationServerMetadata,
+  generateClerkProtectedResourceMetadata,
+  generateProtectedResourceMetadata,
+  verifyClerkToken,
+} from '../server';
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    mcpAuth: AuthInfo;
+  }
+}
+
+export function protectedResourceHandler({
+  authServerUrl,
+  properties,
+}: {
+  authServerUrl: string;
+  properties?: Record<string, unknown>;
+}) {
+  return (c: Context) => {
+    const metadata = generateProtectedResourceMetadata({
+      authServerUrl,
+      resourceUrl: getResourceUrl(c),
+      properties,
+    });
+    return c.json(metadata);
+  };
+}
+
+export function protectedResourceHandlerClerk(properties?: Record<string, unknown>) {
+  return (c: Context) => {
+    const publishableKey = process.env.CLERK_PUBLISHABLE_KEY;
+    if (!publishableKey) {
+      throw new Error('CLERK_PUBLISHABLE_KEY environment variable is required');
+    }
+    const metadata = generateClerkProtectedResourceMetadata({
+      publishableKey,
+      resourceUrl: getResourceUrl(c),
+      properties,
+    });
+    return c.json(metadata);
+  };
+}
+
+export async function authServerMetadataHandlerClerk(c: Context) {
+  const publishableKey = process.env.CLERK_PUBLISHABLE_KEY;
+  if (!publishableKey) {
+    throw new Error('CLERK_PUBLISHABLE_KEY environment variable is required');
+  }
+  const metadata = await fetchClerkAuthorizationServerMetadata({ publishableKey });
+  return c.json(metadata);
+}
+
+export function mcpAuth(
+  verifyToken: (token: string, c: Context) => Promise<AuthInfo | undefined>,
+): MiddlewareHandler {
+  return async (c: Context, next: Next) => {
+    const prmUrl = getPRMUrl(c);
+
+    if (!c.req.header('authorization')) {
+      return c.json(
+        { error: 'Unauthorized' },
+        {
+          status: 401,
+          headers: { 'WWW-Authenticate': `Bearer resource_metadata=${prmUrl}` },
+        },
+      );
+    }
+
+    const authHeader = c.req.header('authorization')!;
+    const token = authHeader.split(' ')[1];
+
+    if (!token) {
+      throw new Error(
+        `Invalid authorization header value, expected Bearer <token>, received ${authHeader}`,
+      );
+    }
+
+    const authData = await verifyToken(token, c);
+
+    if (!authData) {
+      return c.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    c.set('mcpAuth', authData);
+    await next();
+  };
+}
+
+export async function mcpAuthClerk(c: Context, next: Next): Promise<Response | void> {
+  return mcpAuth(async (token, ctx) => {
+    const authData = getAuth(ctx, { acceptsToken: 'oauth_token' });
+    if (!authData.isAuthenticated) return undefined;
+    return verifyClerkToken(authData, token);
+  })(c, next);
+}
+
+export function streamableHttpHandler(server: McpServer) {
+  return async (c: Context) => {
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+    await server.connect(transport);
+    const req = c.req.raw;
+    const accept = req.headers.get('accept') ?? '';
+    const needsAccept =
+      !accept.includes('application/json') || !accept.includes('text/event-stream');
+    const forwardedReq = needsAccept
+      ? new Request(req, {
+          headers: new Headers({
+            ...Object.fromEntries(req.headers.entries()),
+            accept: 'application/json, text/event-stream',
+          }),
+        })
+      : req;
+    return transport.handleRequest(forwardedReq, { authInfo: c.get('mcpAuth') as AuthInfo | undefined });
+  };
+}
+
+function getResourceUrl(c: Context): string {
+  const url = new URL(c.req.url);
+  url.pathname = url.pathname.replace(/\.well-known\/oauth-protected-resource\/?/, '');
+  return url.toString();
+}
+
+function getPRMUrl(c: Context): string {
+  const url = new URL(c.req.url);
+  return `${url.origin}/.well-known/oauth-protected-resource${url.pathname}`;
+}

--- a/hono/index.ts
+++ b/hono/index.ts
@@ -95,23 +95,14 @@ export const mcpAuthClerk = mcpAuth(async (token, c) => {
   return verifyClerkToken(authData, token);
 });
 
-export function streamableHttpHandler(server: McpServer) {
-  let previousRequest = Promise.resolve();
-
+export function streamableHttpHandler(createServer: () => McpServer) {
   return async (c: Context) => {
-    const waitForPreviousRequest = previousRequest;
-    let releaseRequest!: () => void;
-    previousRequest = new Promise<void>((resolve) => {
-      releaseRequest = resolve;
-    });
-
-    await waitForPreviousRequest;
-
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
     });
 
     try {
+      const server = createServer();
       await server.connect(transport);
       const response = await transport.handleRequest(c.req.raw, {
         authInfo: c.get('mcpAuth'),
@@ -119,31 +110,18 @@ export function streamableHttpHandler(server: McpServer) {
 
       if (!response.body) {
         await transport.close();
-        releaseRequest();
         return response;
       }
 
-      // Keep the server attached until the response is consumed, while making
-      // later requests wait for transport.close() to release the server.
       const { readable, writable } = new TransformStream();
       void response.body
         .pipeTo(writable)
-        .finally(async () => {
-          try {
-            await transport.close();
-          } finally {
-            releaseRequest();
-          }
-        })
+        .finally(() => transport.close())
         .catch(() => undefined);
 
       return new Response(readable, { status: response.status, headers: response.headers });
     } catch (error) {
-      try {
-        await transport.close();
-      } finally {
-        releaseRequest();
-      }
+      await transport.close().catch(() => undefined);
       throw error;
     }
   };

--- a/hono/index.ts
+++ b/hono/index.ts
@@ -96,32 +96,56 @@ export const mcpAuthClerk = mcpAuth(async (token, c) => {
 });
 
 export function streamableHttpHandler(server: McpServer) {
+  let previousRequest = Promise.resolve();
+
   return async (c: Context) => {
+    const waitForPreviousRequest = previousRequest;
+    let releaseRequest!: () => void;
+    previousRequest = new Promise<void>((resolve) => {
+      releaseRequest = resolve;
+    });
+
+    await waitForPreviousRequest;
+
     const transport = new WebStandardStreamableHTTPServerTransport({
       sessionIdGenerator: undefined,
     });
-    await server.connect(transport);
-    const req = c.req.raw;
-    let response: Response;
+
     try {
-      response = await transport.handleRequest(req, {
+      await server.connect(transport);
+      const response = await transport.handleRequest(c.req.raw, {
         authInfo: c.get('mcpAuth'),
       });
+
+      if (!response.body) {
+        await transport.close();
+        releaseRequest();
+        return response;
+      }
+
+      // Keep the server attached until the response is consumed, while making
+      // later requests wait for transport.close() to release the server.
+      const { readable, writable } = new TransformStream();
+      void response.body
+        .pipeTo(writable)
+        .finally(async () => {
+          try {
+            await transport.close();
+          } finally {
+            releaseRequest();
+          }
+        })
+        .catch(() => undefined);
+
+      return new Response(readable, { status: response.status, headers: response.headers });
     } catch (error) {
-      await transport.close();
+      try {
+        await transport.close();
+      } finally {
+        releaseRequest();
+      }
       throw error;
     }
-
-    if (!response.body) {
-      await transport.close();
-      return response;
-    }
-
-    // Pipe the body through a TransformStream so transport.close() is called
-    // only after the response stream is fully consumed, not before.
-    const { readable, writable } = new TransformStream();
-    response.body.pipeTo(writable).finally(() => transport.close());
-    return new Response(readable, { status: response.status, headers: response.headers });
   };
 }
 

--- a/hono/index.ts
+++ b/hono/index.ts
@@ -77,8 +77,12 @@ export function mcpAuth(
     const token = authHeader.split(' ')[1];
 
     if (!token) {
-      throw new Error(
-        `Invalid authorization header value, expected Bearer <token>, received ${authHeader}`,
+      return c.json(
+        { error: 'Unauthorized' },
+        {
+          status: 401,
+          headers: { 'WWW-Authenticate': `Bearer resource_metadata=${prmUrl}` },
+        },
       );
     }
 
@@ -119,7 +123,11 @@ export function streamableHttpHandler(server: McpServer) {
           }),
         })
       : req;
-    return transport.handleRequest(forwardedReq, { authInfo: c.get('mcpAuth') as AuthInfo | undefined });
+    try {
+      return await transport.handleRequest(forwardedReq, { authInfo: c.get('mcpAuth') as AuthInfo | undefined });
+    } finally {
+      await transport.close();
+    }
   };
 }
 

--- a/hono/index.ts
+++ b/hono/index.ts
@@ -123,11 +123,26 @@ export function streamableHttpHandler(server: McpServer) {
           }),
         })
       : req;
+    let response: Response;
     try {
-      return await transport.handleRequest(forwardedReq, { authInfo: c.get('mcpAuth') as AuthInfo | undefined });
-    } finally {
+      response = await transport.handleRequest(forwardedReq, {
+        authInfo: c.get('mcpAuth') as AuthInfo | undefined,
+      });
+    } catch (e) {
       await transport.close();
+      throw e;
     }
+
+    if (!response.body) {
+      await transport.close();
+      return response;
+    }
+
+    // Pipe the body through a TransformStream so transport.close() is called
+    // only after the response stream is fully consumed, not before.
+    const { readable, writable } = new TransformStream();
+    response.body.pipeTo(writable).finally(() => transport.close());
+    return new Response(readable, { status: response.status, headers: response.headers });
   };
 }
 

--- a/hono/index.ts
+++ b/hono/index.ts
@@ -1,8 +1,9 @@
 import { getAuth } from '@clerk/hono';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js';
 import type { Context, MiddlewareHandler, Next } from 'hono';
+import { env } from 'hono/adapter';
 import {
   fetchClerkAuthorizationServerMetadata,
   generateClerkProtectedResourceMetadata,
@@ -15,6 +16,10 @@ declare module 'hono' {
     mcpAuth: AuthInfo;
   }
 }
+
+type ClerkEnv = {
+  CLERK_PUBLISHABLE_KEY?: string;
+};
 
 export function protectedResourceHandler({
   authServerUrl,
@@ -35,7 +40,7 @@ export function protectedResourceHandler({
 
 export function protectedResourceHandlerClerk(properties?: Record<string, unknown>) {
   return (c: Context) => {
-    const publishableKey = process.env.CLERK_PUBLISHABLE_KEY;
+    const publishableKey = env<ClerkEnv>(c).CLERK_PUBLISHABLE_KEY;
     if (!publishableKey) {
       throw new Error('CLERK_PUBLISHABLE_KEY environment variable is required');
     }
@@ -49,7 +54,7 @@ export function protectedResourceHandlerClerk(properties?: Record<string, unknow
 }
 
 export async function authServerMetadataHandlerClerk(c: Context) {
-  const publishableKey = process.env.CLERK_PUBLISHABLE_KEY;
+  const publishableKey = env<ClerkEnv>(c).CLERK_PUBLISHABLE_KEY;
   if (!publishableKey) {
     throw new Error('CLERK_PUBLISHABLE_KEY environment variable is required');
   }
@@ -61,29 +66,16 @@ export function mcpAuth(
   verifyToken: (token: string, c: Context) => Promise<AuthInfo | undefined>,
 ): MiddlewareHandler {
   return async (c: Context, next: Next) => {
-    const prmUrl = getPRMUrl(c);
+    const authHeader = c.req.header('authorization');
 
-    if (!c.req.header('authorization')) {
-      return c.json(
-        { error: 'Unauthorized' },
-        {
-          status: 401,
-          headers: { 'WWW-Authenticate': `Bearer resource_metadata=${prmUrl}` },
-        },
-      );
+    if (!authHeader) {
+      return unauthorized(c);
     }
 
-    const authHeader = c.req.header('authorization')!;
-    const token = authHeader.split(' ')[1];
+    const [scheme, token, ...rest] = authHeader.trim().split(/\s+/);
 
-    if (!token) {
-      return c.json(
-        { error: 'Unauthorized' },
-        {
-          status: 401,
-          headers: { 'WWW-Authenticate': `Bearer resource_metadata=${prmUrl}` },
-        },
-      );
+    if (scheme?.toLowerCase() !== 'bearer' || !token || rest.length > 0) {
+      return unauthorized(c);
     }
 
     const authData = await verifyToken(token, c);
@@ -97,13 +89,11 @@ export function mcpAuth(
   };
 }
 
-export async function mcpAuthClerk(c: Context, next: Next): Promise<Response | void> {
-  return mcpAuth(async (token, ctx) => {
-    const authData = getAuth(ctx, { acceptsToken: 'oauth_token' });
-    if (!authData.isAuthenticated) return undefined;
-    return verifyClerkToken(authData, token);
-  })(c, next);
-}
+export const mcpAuthClerk = mcpAuth(async (token, c) => {
+  const authData = getAuth(c, { acceptsToken: 'oauth_token' });
+  if (!authData.isAuthenticated) return undefined;
+  return verifyClerkToken(authData, token);
+});
 
 export function streamableHttpHandler(server: McpServer) {
   return async (c: Context) => {
@@ -112,25 +102,14 @@ export function streamableHttpHandler(server: McpServer) {
     });
     await server.connect(transport);
     const req = c.req.raw;
-    const accept = req.headers.get('accept') ?? '';
-    const needsAccept =
-      !accept.includes('application/json') || !accept.includes('text/event-stream');
-    const forwardedReq = needsAccept
-      ? new Request(req, {
-          headers: new Headers({
-            ...Object.fromEntries(req.headers.entries()),
-            accept: 'application/json, text/event-stream',
-          }),
-        })
-      : req;
     let response: Response;
     try {
-      response = await transport.handleRequest(forwardedReq, {
-        authInfo: c.get('mcpAuth') as AuthInfo | undefined,
+      response = await transport.handleRequest(req, {
+        authInfo: c.get('mcpAuth'),
       });
-    } catch (e) {
+    } catch (error) {
       await transport.close();
-      throw e;
+      throw error;
     }
 
     if (!response.body) {
@@ -155,4 +134,14 @@ function getResourceUrl(c: Context): string {
 function getPRMUrl(c: Context): string {
   const url = new URL(c.req.url);
   return `${url.origin}/.well-known/oauth-protected-resource${url.pathname}`;
+}
+
+function unauthorized(c: Context) {
+  return c.json(
+    { error: 'Unauthorized' },
+    {
+      status: 401,
+      headers: { 'WWW-Authenticate': `Bearer resource_metadata=${getPRMUrl(c)}` },
+    },
+  );
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
       "import": "./dist/express/index.mjs",
       "types": "./dist/express/index.d.mts"
     },
+    "./hono": {
+      "import": "./dist/hono/index.mjs",
+      "types": "./dist/hono/index.d.mts"
+    },
     "./stores": "./dist/stores",
     "./stores/fs": {
       "import": "./dist/stores/fs.mjs",
@@ -72,7 +76,9 @@
     "lint": "oxlint",
     "lint:fix": "oxlint --fix",
     "fmt": "oxfmt",
-    "fmt:check": "oxfmt --check"
+    "fmt:check": "oxfmt --check",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0"
@@ -80,25 +86,30 @@
   "devDependencies": {
     "@clerk/backend": "^3.2.13",
     "@clerk/express": "^2.1.5",
+    "@clerk/hono": "^0.1.15",
     "@clerk/nextjs": "^7.2.3",
     "@types/better-sqlite3": "^7.6.13",
     "@types/express": "^5.0.3",
     "@types/node": "^24.1.0",
     "@types/pg": "^8.15.4",
     "better-sqlite3": "^11.10.0",
+    "hono": "^4.12.14",
     "next": "^15.5.15",
     "oxfmt": "^0.45.0",
     "oxlint": "^1.60.0",
     "pg": "^8.16.3",
     "redis": "^5.5.6",
     "tsdown": "^0.21.9",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.4"
   },
   "peerDependencies": {
     "@clerk/express": "^2.1.5",
+    "@clerk/hono": "^0.1.0",
     "@clerk/nextjs": "^7.2.3",
     "better-sqlite3": "^8.7.0",
     "express": "^5.0.0",
+    "hono": "^4.0.0",
     "next": "^15.2.8 || ^15.3.8 || ^15.4.10 || ^15.5.9 || ^15.6.0-0 || ^16.0.10 || ^16.1.0-0",
     "pg": "^8.11.0",
     "redis": "^4.0.0"
@@ -107,10 +118,16 @@
     "@clerk/express": {
       "optional": true
     },
+    "@clerk/hono": {
+      "optional": true
+    },
     "@clerk/nextjs": {
       "optional": true
     },
     "express": {
+      "optional": true
+    },
+    "hono": {
       "optional": true
     },
     "next": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   },
   "files": [
     "dist",
+    "hono/README.md",
     "README.md",
     "LICENSE"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,9 +294,6 @@ packages:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/sourcemap-codec@1.5.0':
-    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
-
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -2075,19 +2072,17 @@ snapshots:
 
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
       '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
-
-  '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.27)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
       '@clerk/express':
         specifier: ^2.1.5
         version: 2.1.5(express@5.2.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@clerk/hono':
+        specifier: ^0.1.15
+        version: 0.1.15(hono@4.12.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@clerk/nextjs':
         specifier: ^7.2.3
         version: 7.2.3(next@15.5.15(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -39,6 +42,9 @@ importers:
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
+      hono:
+        specifier: ^4.12.14
+        version: 4.12.14
       next:
         specifier: ^15.5.15
         version: 15.5.15(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -60,6 +66,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@types/node@24.1.0)(vite@8.0.9(@types/node@24.1.0))
 
 packages:
 
@@ -93,6 +102,12 @@ packages:
     engines: {node: '>=20.9.0'}
     peerDependencies:
       express: ^4.17.0 || ^5.0.0
+
+  '@clerk/hono@0.1.15':
+    resolution: {integrity: sha512-hkyhtSmaImKel3CP3T2z76F3Ro9xyBrxsxcXa7BFkXsw7J1R6F0mWitSO9mTfUoNgfWqopEzyRtZ+pT2ItkE9g==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      hono: '>=4'
 
   '@clerk/nextjs@7.2.3':
     resolution: {integrity: sha512-/+SBW09/Dz7pvIabzSKssHTdoGZn2n/k9u/VhIra700gfsymCAR57NLn7ztW6zjPdw5VMILOMTLqzyqxaal3og==}
@@ -281,6 +296,9 @@ packages:
 
   '@jridgewell/sourcemap-codec@1.5.0':
     resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
@@ -735,6 +753,9 @@ packages:
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -750,8 +771,14 @@ packages:
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.7':
     resolution: {integrity: sha512-w28IoSUCJpidD/TGviZwwMJckNESJZXFu7NBZ5YJ4mEUnNraUn9Pm8HSZm/jDF1pDWYKspWE7oVphigUPRakIQ==}
@@ -789,6 +816,35 @@ packages:
   '@types/serve-static@1.15.8':
     resolution: {integrity: sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==}
 
+  '@vitest/expect@4.1.4':
+    resolution: {integrity: sha512-iPBpra+VDuXmBFI3FMKHSFXp3Gx5HfmSCE8X67Dn+bwephCnQCaB7qWK2ldHa+8ncN8hJU8VTMcxjPpyMkUjww==}
+
+  '@vitest/mocker@4.1.4':
+    resolution: {integrity: sha512-R9HTZBhW6yCSGbGQnDnH3QHfJxokKN4KB+Yvk9Q1le7eQNYwiCyKxmLmurSpFy6BzJanSLuEUDrD+j97Q+ZLPg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.4':
+    resolution: {integrity: sha512-ddmDHU0gjEUyEVLxtZa7xamrpIefdEETu3nZjWtHeZX4QxqJ7tRxSteHVXJOcr8jhiLoGAhkK4WJ3WqBpjx42A==}
+
+  '@vitest/runner@4.1.4':
+    resolution: {integrity: sha512-xTp7VZ5aXP5ZJrn15UtJUWlx6qXLnGtF6jNxHepdPHpMfz/aVPx+htHtgcAL2mDXJgKhpoo2e9/hVJsIeFbytQ==}
+
+  '@vitest/snapshot@4.1.4':
+    resolution: {integrity: sha512-MCjCFgaS8aZz+m5nTcEcgk/xhWv0rEH4Yl53PPlMXOZ1/Ka2VcZU6CJ+MgYCZbcJvzGhQRjVrGQNZqkGPttIKw==}
+
+  '@vitest/spy@4.1.4':
+    resolution: {integrity: sha512-XxNdAsKW7C+FLydqFJLb5KhJtl3PGCMmYwFRfhvIgxJvLSXhhVI1zM8f1qD3Zg7RCjTSzDVyct6sghs9UEgBEQ==}
+
+  '@vitest/utils@4.1.4':
+    resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -807,6 +863,10 @@ packages:
   ansis@4.2.0:
     resolution: {integrity: sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==}
     engines: {node: '>=14'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   ast-kit@3.0.0-beta.1:
     resolution: {integrity: sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw==}
@@ -853,6 +913,10 @@ packages:
   caniuse-lite@1.0.30001718:
     resolution: {integrity: sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
@@ -884,6 +948,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -968,6 +1035,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -993,6 +1063,10 @@ packages:
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
     engines: {node: '>=6'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   express-rate-limit@8.3.2:
     resolution: {integrity: sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==}
@@ -1039,6 +1113,11 @@ packages:
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
@@ -1134,6 +1213,83 @@ packages:
 
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1301,6 +1457,10 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postgres-array@2.0.0:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
@@ -1457,6 +1617,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   simple-concat@1.0.1:
     resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
 
@@ -1474,6 +1637,9 @@ packages:
     resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standardwebhooks@1.0.0:
     resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
 
@@ -1483,6 +1649,9 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -1511,6 +1680,9 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
@@ -1522,6 +1694,10 @@ packages:
   tinypool@2.1.0:
     resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
     engines: {node: ^20.0.0 || >=22.0.0}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
@@ -1601,9 +1777,98 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite@8.0.9:
+    resolution: {integrity: sha512-t7g7GVRpMXjNpa67HaVWI/8BWtdVIQPCL2WoozXXA7LBGEFK4AkkKkHx2hAQf5x1GZSlcmEDPkVLSGahxnEEZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.1.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.4:
+    resolution: {integrity: sha512-tFuJqTxKb8AvfyqMfnavXdzfy3h3sWZRWwfluGbkeR7n0HUev+FmNgZ8SDrRBTVrVCjgH5cA21qGbCffMNtWvg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.4
+      '@vitest/browser-preview': 4.1.4
+      '@vitest/browser-webdriverio': 4.1.4
+      '@vitest/coverage-istanbul': 4.1.4
+      '@vitest/coverage-v8': 4.1.4
+      '@vitest/ui': 4.1.4
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wrappy@1.0.2:
@@ -1660,6 +1925,15 @@ snapshots:
       '@clerk/shared': 4.8.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       express: 5.2.1
       tslib: 2.8.1
+    transitivePeerDependencies:
+      - react
+      - react-dom
+
+  '@clerk/hono@0.1.15(hono@4.12.14)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@clerk/backend': 3.2.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@clerk/shared': 4.8.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      hono: 4.12.14
     transitivePeerDependencies:
       - react
       - react-dom
@@ -1807,6 +2081,8 @@ snapshots:
   '@jridgewell/resolve-uri@3.1.2': {}
 
   '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
@@ -2061,6 +2337,8 @@ snapshots:
 
   '@stablelib/base64@1.0.1': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -2081,9 +2359,16 @@ snapshots:
       '@types/connect': 3.4.38
       '@types/node': 24.1.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/connect@3.4.38':
     dependencies:
       '@types/node': 24.1.0
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.7': {}
 
@@ -2131,6 +2416,47 @@ snapshots:
       '@types/node': 24.1.0
       '@types/send': 0.17.5
 
+  '@vitest/expect@4.1.4':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(vite@8.0.9(@types/node@24.1.0))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.9(@types/node@24.1.0)
+
+  '@vitest/pretty-format@4.1.4':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.4':
+    dependencies:
+      '@vitest/utils': 4.1.4
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/utils': 4.1.4
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.4': {}
+
+  '@vitest/utils@4.1.4':
+    dependencies:
+      '@vitest/pretty-format': 4.1.4
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -2148,6 +2474,8 @@ snapshots:
       require-from-string: 2.0.2
 
   ansis@4.2.0: {}
+
+  assertion-error@2.0.1: {}
 
   ast-kit@3.0.0-beta.1:
     dependencies:
@@ -2209,6 +2537,8 @@ snapshots:
 
   caniuse-lite@1.0.30001718: {}
 
+  chai@6.2.2: {}
+
   chownr@1.1.4: {}
 
   client-only@0.0.1: {}
@@ -2238,6 +2568,8 @@ snapshots:
   content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-signature@1.2.2: {}
 
@@ -2294,6 +2626,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@2.0.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -2313,6 +2647,8 @@ snapshots:
       eventsource-parser: 3.0.6
 
   expand-template@2.0.3: {}
+
+  expect-type@1.3.0: {}
 
   express-rate-limit@8.3.2(express@5.2.1):
     dependencies:
@@ -2380,6 +2716,9 @@ snapshots:
   fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
 
   function-bind@1.1.2: {}
 
@@ -2461,6 +2800,59 @@ snapshots:
   json-schema-traverse@1.0.0: {}
 
   json-schema-typed@8.0.2: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   math-intrinsics@1.1.0: {}
 
@@ -2625,6 +3017,12 @@ snapshots:
   pkce-challenge@5.0.1: {}
 
   postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2862,6 +3260,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -2879,6 +3279,8 @@ snapshots:
 
   split2@4.2.0: {}
 
+  stackback@0.0.2: {}
+
   standardwebhooks@1.0.0:
     dependencies:
       '@stablelib/base64': 1.0.1
@@ -2887,6 +3289,8 @@ snapshots:
   statuses@2.0.2: {}
 
   std-env@3.10.0: {}
+
+  std-env@4.1.0: {}
 
   string_decoder@1.3.0:
     dependencies:
@@ -2914,6 +3318,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.16:
@@ -2922,6 +3328,8 @@ snapshots:
       picomatch: 4.0.4
 
   tinypool@2.1.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   toidentifier@1.0.1: {}
 
@@ -2985,9 +3393,52 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite@8.0.9(@types/node@24.1.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.16
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.1.0
+      fsevents: 2.3.3
+
+  vitest@4.1.4(@types/node@24.1.0)(vite@8.0.9(@types/node@24.1.0)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(vite@8.0.9(@types/node@24.1.0))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
+      tinyrainbow: 3.1.0
+      vite: 8.0.9(@types/node@24.1.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 24.1.0
+    transitivePeerDependencies:
+      - msw
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wrappy@1.0.2: {}
 

--- a/server.ts
+++ b/server.ts
@@ -1,4 +1,4 @@
-import { MachineAuthObject } from '@clerk/backend';
+import type { MachineAuthObject } from '@clerk/backend';
 import type { AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 
 /**
@@ -75,7 +75,9 @@ export function generateClerkProtectedResourceMetadata({
 
 function deriveFapiUrl(publishableKey: string) {
   const key = publishableKey.replace(/^pk_(test|live)_/, '');
-  const decoded = Buffer.from(key, 'base64').toString('utf8');
+  const normalizedKey = key.replace(/-/g, '+').replace(/_/g, '/');
+  const paddedKey = normalizedKey.padEnd(Math.ceil(normalizedKey.length / 4) * 4, '=');
+  const decoded = atob(paddedKey);
   return `https://${decoded.replace(/\$/, '')}`;
 }
 

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     'server.ts',
     'next/index.ts',
     'express/index.ts',
+    'hono/index.ts',
     'stores/fs.ts',
     'stores/redis.ts',
     'stores/postgres.ts',
@@ -23,6 +24,8 @@ export default defineConfig({
       '@clerk/express',
       '@clerk/nextjs',
       'express',
+      'hono',
+      '@clerk/hono',
     ],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});


### PR DESCRIPTION
- Adds `@clerk/mcp-tools/hono` with the same API surface as the Express adapter: `mcpAuth`, 
 `mcpAuthClerk`, `protectedResourceHandler`, `protectedResourceHandlerClerk`,
  authServerMetadataHandlerClerk, and streamableHttpHandler
- Uses `WebStandardStreamableHTTPServerTransport` instead of the Node.js-only transport used by
  Express, making it compatible with edge runtimes and Cloudflare Workers
- Auth data set by middleware flows into the MCP transport via `HandleRequestOptions.authInfo`,
  consistent with how the Express adapter wires things up
- Adds Vitest and unit tests covering all exports
- Updates the CI workflow to run tests on every PR