### PR TITLE
Fix stores export entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,10 @@
       "import": "./dist/express/index.mjs",
       "types": "./dist/express/index.d.mts"
     },
-    "./stores": "./dist/stores",
+    "./stores": {
+      "import": "./dist/stores/index.mjs",
+      "types": "./dist/stores/index.d.mts"
+    },
     "./stores/fs": {
       "import": "./dist/stores/fs.mjs",
       "types": "./dist/stores/fs.d.mts"

--- a/stores/index.ts
+++ b/stores/index.ts
@@ -1,0 +1,4 @@
+export * from './fs.js';
+export * from './postgres.js';
+export * from './redis.js';
+export * from './sqlite.js';

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     'server.ts',
     'next/index.ts',
     'express/index.ts',
+    'stores/index.ts',
     'stores/fs.ts',
     'stores/redis.ts',
     'stores/postgres.ts',


### PR DESCRIPTION
Summary
- add a stores index barrel so the aggregate stores subpath has a real build entry
- include the stores index in the tsdown entry list
- point `./stores` at the generated ESM/types files instead of the `dist/stores` directory

Verification
- package export map now targets `./dist/stores/index.mjs` and `./dist/stores/index.d.mts`
- `stores/index.ts` re-exports the existing fs/postgres/redis/sqlite store modules
