### PR TITLE
Fix authorization server metadata README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,47 +80,17 @@ For framework-specific implementations of protected resource metadata handlers, 
 
 > **NOTE:** This is not yet fully implemented
 
-There is [an older version of the MCP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization#2-5-authorization-flow-steps) that specified that the MCP server should be responsible for authentication on its own and instead it should implement a different static metadata file called "authorization server metadata", defined by [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414). While it should not be necessary as long as you have implemented protected resource metadata and are using an authorization service that has properly implemented an authorization server metadata route, there are some scenarios where this might be necessary if you are building your own authorization server, if your authorization server is part of your app directly, or if you are interfacing with a client that has an outdated implementation. This library also provides utilities for this use case.
+An [older version of the MCP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/authorization#2-5-authorization-flow-steps) required MCP servers to publish a separate "authorization server metadata" document, defined by [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414). Most deployments no longer need this endpoint when they publish protected resource metadata and use an authorization service with its own metadata endpoint. You may still need it for a custom or embedded authorization server or an older MCP client.
+
+If you use [Clerk](https://clerk.com) for authentication, fetch the metadata from your Clerk Frontend API and return it from your authorization server metadata endpoint.
 
 ```ts
-// return this result from <your-app>/.well-known/oauth-authorization-server
-import { generateAuthorizationServerMetadata } from '@clerk/mcp-tools/server';
+import { fetchClerkAuthorizationServerMetadata } from '@clerk/mcp-tools/server';
 
-const result = generateAuthorizationServerMetadata({
-  authServerUrl: 'https://auth.example.com',
-  scopes: ['email', 'profile', 'openid'],
+// Return this result from <your-app>/.well-known/oauth-authorization-server
+const result = await fetchClerkAuthorizationServerMetadata({
+  publishableKey: process.env.CLERK_PUBLISHABLE_KEY,
 });
-```
-
-In the most standard case, the above example will work, but it does make some assumptions about the authorization server, namely that:
-
-- The authorization endpoint is: `<authServerUrl>/authorize`
-- The registration endpoint is: `<authServerUrl>/register`
-- The token endpoint is: `<authServerUrl>/token`
-- The userInfo endpoint is: `<authServerUrl>/userinfo`
-- The jwks endpoint is: `<authServerUrl>/.well-known/jwks.json`
-
-If this isn't the case, you can pass in overrides for any of these values. Passing in false will omit the value, which can be useful in some cases, like if your authorization server does not support dynamic client registration:
-
-```ts
-// return this result from <your-app>/.well-known/oauth-authorization-server
-import { generateAuthorizationServerMetadata } from '@clerk/mcp-tools/server';
-
-const result = generateAuthorizationServerMetadata({
-  authServerUrl: 'https://auth.example.com',
-  authorizationEndpoint: 'foo/bar/authorize',
-  registrationEndpoint: false,
-  tokenEndpoint: 'tokens',
-  scopes: ['email', 'profile', 'openid', 'foobar'],
-});
-```
-
-If you are using [Clerk](https://clerk.com) for authentication in your app, you can use the following helper to fetch Clerk's metadata from your Clerk frontend API and return it.
-
-```ts
-import { generateClerkAuthorizationServerMetadata } from '@clerk/mcp-tools/server';
-
-const result = generateClerkAuthorizationServerMetadata();
 ```
 
 For framework-specific implementations, see:


### PR DESCRIPTION
## Summary

- Remove README examples for the unsupported `generateAuthorizationServerMetadata` helper.
- Update the Clerk example to use the exported async `fetchClerkAuthorizationServerMetadata` helper.
- Preserve the compatibility context and current Express, Hono, and Next.js links.

## Why

The README directs developers to two functions that the package does not export. This update aligns the documentation with the current server API so the example can be implemented without discovering the mismatch at build time.

Fixes #6.
Supersedes #7 with the same correction applied to current `main`.

## Validation

- `pnpm run fmt:check`
- `pnpm run lint`
- `pnpm run test` (24 tests)
